### PR TITLE
Do a pull at build time for base image

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -154,9 +154,9 @@ build_image() {
     pushd "$HERE/.." >/dev/null
     echo $GIT_VERSION > git.version
     if [ $MULTI_PLATFORM == true ]; then
-        docker buildx build $NOCACHE_ARG -t $IMAGE -f docker/Dockerfile --platform linux/amd64,linux/arm64 --push .
+        docker buildx build $NOCACHE_ARG --pull -t $IMAGE -f docker/Dockerfile --platform linux/amd64,linux/arm64 --push .
     else
-        docker build $NOCACHE_ARG -t $IMAGE -f docker/Dockerfile .
+        docker build $NOCACHE_ARG --pull -t $IMAGE -f docker/Dockerfile .
     fi
     rm -f git.version
     RETVAL=$?


### PR DESCRIPTION
The build process could be using a stale base image. Be sure to pull so we get latest and fresh fixes.