### PR TITLE
Fix: ssn path should be initialised for startup

### DIFF
--- a/scripts/crontab
+++ b/scripts/crontab
@@ -55,7 +55,7 @@ LANG=C
 25 8 * * *     $VENV/bin/python3 $BASE/scripts/gen_dxpeditions_spots.py >> $BASE/logs/dxpeds.log 2>&1
 
 0 1 * * *      $BASE/scripts/gen_solarflux-history.sh   >> /opt/hamclock-backend/logs/gen_solarflux-history.log 2>&1
-0 1 * * *      $BASE/scripts/gen_ssn_history.pl         >> /opt/hamclock-backend/logs/gen_ssn_history.pl 2>&1
+0 1 * * *      $BASE/scripts/gen_ssn_history.pl         >> /opt/hamclock-backend/logs/gen_ssn_history.log 2>&1
 15 3 * * 0     $BASE/scripts/update_pota_parks_cache.sh >> /opt/hamclock-backend/logs/update_pota_parks_cache.log 2>&1
 
 */30 * * * *   $VENV/bin/python3 $BASE/scripts/web15rss_fetch.py >> $BASE/logs/web15rss_fetch.log 2>&1


### PR DESCRIPTION
When starting a new set of OHB containers under docker, the `voacap-service` can fail if it attempts to attach the `ohb-htdocs` volume before any of the ssn scripts have run in the `open-hamclock-backend` and created the `ham/HamClock/ssn` folder. Error appears as follows:

```sh
$ ./manage-ohb-docker.sh install
Installing OHB …
Creeating persistent storage …
Persistent storage created successfully.
Starting the container …
[+] create 4/4
✔ Network ohb Created 0.0s
✔ Container open-hamclock-backend Created 0.0s
✔ Container pskr-mqtt-cache Created 0.0s
✔ Container voacap-service Created 0.0s
[+] up 2/3
✔ Container open-hamclock-backend Healthy 5.6s
✔ Container pskr-mqtt-cache Started 0.4s
⠼ Container voacap-service Starting 0.4s
Error response from daemon: cannot access path /var/lib/docker/volumes/ohb-htdocs/_data/ham/HamClock/ssn: lstat /var/lib/docker/volumes/ohb-htdocs/_data/ham/HamClock/ssn: no such file or directory
ERROR: failed to start OHB with docker compose up
$ docker ps
CONTAINER ID   IMAGE                                  COMMAND                  CREATED          STATUS                    PORTS                                 NAMES
e9fec0ddeaac   komacke/pskr-mqtt-cache:1.11           "python3 -m pskr_mqt…"   29 seconds ago   Up 22 seconds (healthy)   5000/tcp                              pskr-mqtt-cache
94a2bc996095   komacke/open-hamclock-backend:latest   "/opt/run.sh"            29 seconds ago   Up 28 seconds (healthy)   0.0.0.0:80->80/tcp, [::]:80->80/tcp   open-hamclock-backend
$
```

The fox here:

* ensure there's an empty `ham/HamClock/ssn` folder in the sources: `voacap-service` can attach, even if ssn scripts have not run yet
* also fixed the crontab, so that `gen_ssn_history.pl` logs to `gen_ssn_history.log` (previously: `gen_ssn_history.pl`)

## Testing the fix

remove current installation:

```sh
$ ./manage-ohb-docker.sh remove
Stopping the container ...
[+] down 4/4
 ✔ Container voacap-service        Removed                                                                                                                                                  0.3s
 ✔ Container pskr-mqtt-cache       Removed                                                                                                                                                  0.4s
 ✔ Container open-hamclock-backend Removed                                                                                                                                                  1.2s
 ✔ Network ohb                     Removed                                                                                                                                                  0.4s
Container stopped successfully.
Removing persistent storage ...
Persistent storage removed successfully.
```

build fresh image:

```sh
$ ./build-image.sh
NOTE: Not currently on a tag. Using 'latest'.

Building image for 'komacke/open-hamclock-backend:latest'

...


Completed building 'komacke/open-hamclock-backend:latest'.
```

run with new image. no error with startup (also tried this after disabling ssn cron jobs)

```sh
$ ./manage-ohb-docker.sh install
Installing OHB ...
Creeating persistent storage ...
Persistent storage created successfully.
Starting the container ...
[+] create 4/4
 ✔ Network ohb                     Created                                                                                                                                                  0.0s
 ✔ Container open-hamclock-backend Created                                                                                                                                                  0.0s
 ✔ Container pskr-mqtt-cache       Created                                                                                                                                                  0.0s
 ✔ Container voacap-service        Created                                                                                                                                                  0.0s
[+] up 3/3
 ✔ Container open-hamclock-backend Healthy                                                                                                                                                  5.6s
 ✔ Container pskr-mqtt-cache       Started                                                                                                                                                  0.1s
 ✔ Container voacap-service        Started                                                                                                                                                  0.1s
Container started successfully.

$ docker exec -it open-hamclock-backend bash
root@6373cb230fa2:/opt# cat hamclock-backend/logs/gen_ssn_history.log 
gen_ssn_history.pl: updated SSN history (758 rows)

```
