### PR TITLE
Fix mac incompatibilities one-time

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -20,12 +20,7 @@ IMAGE=$IMAGE_BASE:$TAG
 CONTAINER=${IMAGE_BASE##*/}
 
 # Get our directory locations in figured out
-# No -s option for realpath on macos/Darwin
-if [ "$(uname)" = "Darwin" ]; then
-    HERE="$(realpath "$(dirname "$0")")"
-else
-    HERE="$(realpath -s "$(dirname "$0")")"
-fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
 THIS="$(basename "$0")"
 cd $HERE
 

--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -11,8 +11,7 @@ OHB_HTDOCS_DVC=ohb-htdocs
 IMAGE_BASE=komacke/open-hamclock-backend
 
 # Get our directory locations in order
-HERE="$(realpath -s "$(dirname "$0")" 2>/dev/null)"
-[ -z "$HERE" ] && HERE="$(realpath "$(dirname "$0")")"
+HERE="$(cd "$(dirname "$0")" && pwd)"
 THIS="$(basename "$0")"
 STARTED_FROM="$PWD"
 cd $HERE
@@ -526,7 +525,7 @@ copy_env_to_container() {
         if [ -r "$ENV_FILE" ]; then
             docker cp $ENV_FILE $CONTAINER:/opt/hamclock-backend/.env
         else
-            echo "ERROR: ENV file not found: '$(realpath "$ENV_FILE")'" >&2
+            echo "ERROR: ENV file not found: '$ENV_FILE'" >&2
             RETVAL=1
         fi
     else

--- a/docker/one-time-clean.sh
+++ b/docker/one-time-clean.sh
@@ -12,7 +12,7 @@
 # The files are relative to a root of /opt/hamclock-backend/htdocs/state/ which is the docker-mounted volume
 
 THIS=$(basename $0)
-HERE="$(realpath -s "$(dirname "$0")" 2>/dev/null)"
+HERE="$(cd "$(dirname "$0")" && pwd)"
 DVC_MOUNT=/opt/hamclock-backend/htdocs
 STOCK_FILES_LIST=$HERE/${THIS%.*}.txt
 FILES_LIST=$DVC_MOUNT/state/${THIS%.*}.txt
@@ -32,8 +32,15 @@ fi
 cp "$STOCK_FILES_LIST" "$FILES_LIST"
 
 while IFS= read -r file; do
-    echo "$THIS: Deleting: $DVC_MOUNT/$file"
-	rm -f "$DVC_MOUNT/$file"
+    if [ -d "$DVC_MOUNT/$file" ]; then
+        echo "$THIS: Removing directory: $DVC_MOUNT/$file"
+	    rmdir "$DVC_MOUNT/$file"
+    elif [ -f "$DVC_MOUNT/$file" ]; then
+        echo "$THIS: Deleting file: $DVC_MOUNT/$file"
+	    rm -f "$DVC_MOUNT/$file"
+    else
+        echo "$THIS: No such file or directory: $DVC_MOUNT/$file"
+    fi
 done < <(grep -vE '^(\s*#|\s*$)' "$FILES_LIST" | tr -d '\r')
 
 # mark the file as from this image and having been run already.


### PR DESCRIPTION
- mac doesn't like realpath but we don't need it
- one-time clean can clean up dirs and warn if not found