### PR TITLE
[standards] proposed reorganisation of frontend/backend standards and documentation (backend repo)

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -68,7 +68,7 @@ These files never change or are unlikely to need change any time soon.
 ### HamClock Upgrades
 HamClocks check with the backend for new HamClock versions. When available they attempt to pull the source zip file from the backend to upgrade themselves.
 
-- [x] Upgrades to the latest released HamClock version are supported from v1.0.5. The source file comes from https://github.com/komacke/hamclock releases.
+- [x] Upgrades to the latest released HamClock version are supported from v1.0.5. The source file comes from https://github.com/openhamclock/hamclock releases.
 
 ### ESP8266-based devices
 ESP8266-based devices use an older API (some URLs are different) and need a binary for upgrades rather than source.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Bug reports and pull requests are welcome on GitHub at
 
 * [HamClock Standards](https://github.com/openhamclock/hamclock-standards) - specifications source
 * [HamClock Client](https://github.com/openhamclock/hamclock) - reference frontend implementation source
-* [HamClockLauncher](https://github.com/huberthickman/HamClockLauncher) - frontend installer/launcher source
+    * includes Raspberry Pi/Debian and Docker installers
+    * [HamClockLauncher](https://github.com/huberthickman/HamClockLauncher) - macOS frontend installer/launcher source
+    * also many appliances available for sale, with HamClock pre-installed and automatically maintained
 * Open Hamclock Backend project
     * <https://ohb.works/> - main site
     * <https://github.com/komacke/open-hamclock-backend> - source

--- a/README.md
+++ b/README.md
@@ -1,41 +1,66 @@
 # 🛟  📡 OHB — Open HamClock Backend
 
 ## Latest Announcements
+
 For latest information, visit the [announcements page](ANNOUNCEMENTS.md).
 
 ## Release Notes
+
 For a brief summary of each release visit the [OHB Works Project page](https://ohb.works/open-hamclock-backend-status/).
 
 ## What is OHB?
+
 OHB is an open-source, backend replacement for HamClock. It maintains the HamClock interface by dynamically generating live propagation data, maps, and feeds. It can be hosted on compute as small as a Raspberry Pi3B+.
 
+OHB implements, and is fully compatible with, the HamClock Standards as
+defined and managed at <https://github.com/openhamclock/hamclock-standards>.
+
+The "frontend" implementation (aka HamClock or HamClock Client)
+can be found at <https://github.com/komacke/hamclock>.
+
 ## Overview
+
 Mitigates centralized backend risk by enabling deployment across multiple independent, federated instances. Continuity is guaranteed since OHB is open source and easily maintained.
 
 All maps + data feeds are generated on your own compute. Our project only uses publicly documented data sources and runs independently.
 
 ## Important Note
+>
 > This project is not affiliated with HamClock or its creator,
 > Elwood Downey, WB0OEW.
 > We extend our sincere condolences to the Downey family.
 
 ## Compatibility 👉 [Compatibility](COMPATIBILITY.md)
+
 ## 💬 Join us on Discord
+
 We are building a community-powered backend to keep HamClock running. \
 Discord is where we can collaborate, troubleshoot, and exchange ideas — no RF license required 😎 \
-https://discord.gg/wb8ATjVn6M
+<https://discord.gg/wb8ATjVn6M>
 
 ## 🚀 Quick Start 👉 [Quick Start Guide](QUICK_START.md)
+
 ## 📦 Installation 👉 [Detailed installation instructions](INSTALL.md)
+
 ## 📊 Project Completion Status
+
 👉 Full artifact tracking and integration status:
-[PROJECT_STATUS.md](PROJECT_STATUS.md) 
+[PROJECT_STATUS.md](PROJECT_STATUS.md)
+
 ## 📚 Data Attribution 👉 [Attribution](ATTRIBUTION.md)
+
 All we ask is if you fork OHB that you clearly list what parts of OHB you re-used and what parts you changed.
+
 ## 🤝 Contributing
+
 Bug reports and pull requests are welcome on GitHub at
-https://github.com/komacke/open-hamclock-backend/issues
+<https://github.com/komacke/open-hamclock-backend/issues>
+
 ## 📄 Disclaimer 👉 [Disclaimer](./DISCLAIMER.md)
+
 ## Related
-- [HamClockLauncher](https://github.com/huberthickman/HamClockLauncher)
-- [HamClock Web in Docker](https://github.com/komacke/hamclock)
+
+* [HamClock Client](https://github.com/komacke/hamclock) - reference frontend implementation
+* [HamClockLauncher](https://github.com/huberthickman/HamClockLauncher) - frontend installer/launcher
+* [Open HamClock Backend](https://github.com/komacke/open-hamclock-backend) - reference backend implementation
+* [HamClock Standards](https://github.com/openhamclock/hamclock-standards)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ Bug reports and pull requests are welcome on GitHub at
 
 ## Related
 
-* [HamClock Client](https://github.com/komacke/hamclock) - reference frontend implementation
-* [HamClockLauncher](https://github.com/huberthickman/HamClockLauncher) - frontend installer/launcher
-* [Open HamClock Backend](https://github.com/komacke/open-hamclock-backend) - reference backend implementation
-* [HamClock Standards](https://github.com/openhamclock/hamclock-standards)
+* [HamClock Standards](https://github.com/openhamclock/hamclock-standards) - specifications source
+* [HamClock Client](https://github.com/komacke/hamclock) - reference frontend implementation source
+* [HamClockLauncher](https://github.com/huberthickman/HamClockLauncher) - frontend installer/launcher source
+* Open Hamclock Backend project
+    * <https://ohb.works/> - main site
+    * <https://github.com/komacke/open-hamclock-backend> - source
+* [hamclock.com](https://hamclock.com) backend

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Bug reports and pull requests are welcome on GitHub at
 ## Related
 
 * [HamClock Standards](https://github.com/openhamclock/hamclock-standards) - specifications source
-* [HamClock Client](https://github.com/komacke/hamclock) - reference frontend implementation source
+* [HamClock Client](https://github.com/openhamclock/hamclock) - reference frontend implementation source
 * [HamClockLauncher](https://github.com/huberthickman/HamClockLauncher) - frontend installer/launcher source
 * Open Hamclock Backend project
     * <https://ohb.works/> - main site

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OHB implements, and is fully compatible with, the HamClock Standards as
 defined and managed at <https://github.com/openhamclock/hamclock-standards>.
 
 The "frontend" implementation (aka HamClock or HamClock Client)
-can be found at <https://github.com/komacke/hamclock>.
+can be found at <https://github.com/openhamclock/hamclock>.
 
 ## Overview
 


### PR DESCRIPTION
See rationale and discussion in https://github.com/openhamclock/hamclock-standards/pull/8
