### PR TITLE
For the migration of hamclock to org

### DIFF
--- a/scripts/update_versions.pl
+++ b/scripts/update_versions.pl
@@ -7,7 +7,7 @@ use Sort::Versions;
 use Digest::SHA;
 
 # --- Configuration ---
-my $owner      = "komacke";
+my $owner      = "openhamclock";
 my $repo       = "hamclock";
 my $cache_dir  = "/opt/hamclock-backend/cache";
 my $tags_url   = "https://api.github.com/repos/$owner/$repo/tags";


### PR DESCRIPTION
Don't merge this until the hamclock repo has been moved to the openhamclock organization. This should be the only change required.