### PR TITLE
Put in default host of machine getting zips

### DIFF
--- a/docker/package-list.txt
+++ b/docker/package-list.txt
@@ -43,4 +43,5 @@ python3-paho-mqtt
 python3-pyproj
 python3-requests
 python3-sgp4
-
+unzip
+zip

--- a/scripts/update_versions.pl
+++ b/scripts/update_versions.pl
@@ -10,11 +10,13 @@ use Digest::SHA;
 my $owner      = "openhamclock";
 my $repo       = "hamclock";
 my $cache_dir  = "/opt/hamclock-backend/cache";
+my $tmp_dir    = "/opt/hamclock-backend/tmp";
 my $tags_url   = "https://api.github.com/repos/$owner/$repo/tags";
 my $v3_ver     = "3.10";  # Hardcoded legacy version support
-my $host_hostname = $ENV{'HOST_HOSTNAME'} // 'ohb.hamclock.app';
+my $host_hostname = $ENV{'HOST_HOSTNAME'} // $ENV{'HOSTNAME'} // 'ohb.hamclock.app';
 
 mkdir $cache_dir unless -d $cache_dir;
+mkdir $tmp_dir unless -d $tmp_dir;
 
 # Increased timeout to 60s for binary downloads
 my $ua = LWP::UserAgent->new(timeout => 60);
@@ -148,6 +150,24 @@ foreach my $item (
             next;
         }
         print "Successfully saved and verified $zip_path\n";
+
+        # Update wifi.cpp inside zip
+        my $target_file = "ESPHamClock/wifi.cpp";
+        system("unzip -q -o $zip_path $target_file -d $tmp_dir");
+		if (-f "$tmp_dir/$target_file") {
+            # depending on the version, the backend host could be in DEFAULT_HOST or backend_host. Also software_host
+            # might be used
+            system("sed -i -E 's/^(.*(DEFAULT_HOST|backend_host|software_host).* \")[^\"]*(\";?)/\\1$host_hostname\\3/' $tmp_dir/$target_file");
+            system("cd $tmp_dir && zip -q -u $zip_path $target_file");
+            system("rm -rf $tmp_dir/ESPHamClock");
+
+            # Update local SHA file to match modified zip
+            my $new_sha = Digest::SHA->new(256)->addfile($zip_path)->hexdigest;
+            if (open(my $sfh, '>', $zip_sha_path)) {
+                print $sfh "$new_sha  $zip_filename\n";
+                close($sfh);
+            }
+        }
     } else {
         print "Error: Failed to download $zip_filename. Status: " . $zip_resp->status_line . "\n";
         next;


### PR DESCRIPTION
The machine serving the HC source should replace the default version with its own hostname. After someone first upgrades successfully, they'll then default to the same server.

The options to change the backend host still work.