### PR TITLE
Update tags for next release

### DIFF
--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -18,8 +18,8 @@
 # at release time, this value is set to the tagged release
 OHB_MANAGER_VERSION=latest
 # tags to use
-VOACAP_SERVICE_TAG=1.12
-PSKR_MQTT_CACHE_TAG=1.11
+VOACAP_SERVICE_TAG=1.13
+PSKR_MQTT_CACHE_TAG=1.12
 
 GITHUB_LATEST_RELEASE_URL="https://api.github.com/repos/komacke/open-hamclock-backend/releases/latest"
 OHB_HTDOCS_DVC=ohb-htdocs


### PR DESCRIPTION
Setting latest releases for pskr and voacap in anticipation of the next OHB release.