### PR TITLE
Put all crontab calls into nice

### DIFF
--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
-
-# Usage: ./cron-wrapper.sh VAR=val /path/to/bin /path/to/script.py
+# Usage: ./cron-wrapper.sh [--notnice] VAR=val /path/to/bin /path/to/script.py
 
 # 1. Identify the last argument to use as the log filename
-# This ensures "update_world_wx.py" becomes "update_world_wx.log"
 FOR_NAME="${@: -1}"
-SCRIPT_NAME=$(basename "$FOR_NAME" | sed 's/\.[^.]*$//') # Removes .sh, .py, etc.
-
+SCRIPT_NAME=$(basename "$FOR_NAME" | sed 's/\.[^.]*$//')
 LOG_DIR="/opt/hamclock-backend/logs"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}.log"
 LOCK_FILE="/tmp/${SCRIPT_NAME}.lock"
 
 mkdir -p "$LOG_DIR"
+
+# Set up the priority prefix
+CMD_PREFIX=""
+if [ "$1" == "--notnice" ]; then
+    CMD_PREFIX="nice -n 19 ionice -c 2 -n 7"
+    shift
+fi
 
 # 2. Locking Mechanism
 exec 200>"$LOCK_FILE"
@@ -25,14 +29,14 @@ START_TIME=$(date +%s)
 echo "------------------------------------------------------------" >> "$LOG_FILE"
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] START: $@" >> "$LOG_FILE"
 
-# "$@" passes every argument exactly as received (env vars, python path, etc.)
-eval "$@" >> "$LOG_FILE" 2>&1
+# Run the command with priorities and forced shell safety options
+# We use 'bash -euo pipefail -c' to wrap the eval target
+eval "$CMD_PREFIX bash -euo pipefail -c \"$*\"" >> "$LOG_FILE" 2>&1
 EXIT_CODE=$?
 
 # 4. Metrics
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
-
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] END: Exit Code $EXIT_CODE" >> "$LOG_FILE"
 echo "DURATION: ${DURATION} seconds" >> "$LOG_FILE"
 echo "------------------------------------------------------------" >> "$LOG_FILE"

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -28,66 +28,67 @@
 
 SHELL=/bin/bash
 BASE=/opt/hamclock-backend
-VENV=/opt/hamclock-backend/venv
-VIRTUAL_ENV=/opt/hamclock-backend/venv
+SCRIPTS=$BASE/scripts
+VENV=$BASE/venv
+VIRTUAL_ENV=$BASE/venv
 HOME=/var/www
-XDG_CACHE_HOME=/opt/hamclock-backend/tmp
-MPLCONFIGDIR=/opt/hamclock-backend/tmp/mpl
-PATH=/opt/hamclock-backend/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+XDG_CACHE_HOME=$BASE/tmp
+MPLCONFIGDIR=$BASE/tmp/mpl
+PATH=$BASE/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 LC_ALL=C
 LANG=C
 
 # get the latest stable and beta versions
-57 * * * *     $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_versions.pl
+57 * * * *     $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_versions.pl
 
-44 * * * *     $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/ssn_simple.py
-*/5 * * * *    $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/swind_simple.py
-0-58/2 * * * * $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/bz_simple.py
-*/30 * * * *   $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/flux_simple.py
-1-57/4 * * * * $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/xray_simple.py
+44 * * * *     $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/ssn_simple.py
+*/5 * * * *    $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/swind_simple.py
+0-58/2 * * * * $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/bz_simple.py
+*/30 * * * *   $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/flux_simple.py
+1-57/4 * * * * $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/xray_simple.py
 
 # the json updates "estimated" multiple times between its regular 3-hour updates. Also, the 3-hour update isn't
 # an exact time after the 3rd hour. So for the 3 hour updates, we'll do 10 and 40 (AI says it should be ready
 # by 40) and then just do this every hour to catch estimated updates.
-10,40 * * * *  $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/kindex_simple.py
+10,40 * * * *  $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/kindex_simple.py
 
-20,50 * * * *  $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/dst_simple.py
-25 8 * * *     $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/gen_dxpeditions_spots.py
+20,50 * * * *  $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/dst_simple.py
+25 8 * * *     $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/gen_dxpeditions_spots.py
 
-0 1 * * *      $BASE/scripts/cron-wrapper.sh $BASE/scripts/gen_solarflux-history.sh
-0 1 * * *      $BASE/scripts/cron-wrapper.sh $BASE/scripts/gen_ssn_history.pl
-15 3 * * 0     $BASE/scripts/cron-wrapper.sh $BASE/scripts/update_pota_parks_cache.sh
+0 1 * * *      $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_solarflux-history.sh
+0 1 * * *      $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_ssn_history.pl
+15 3 * * 0     $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_pota_parks_cache.sh
 
-*/30 * * * *   $BASE/scripts/cron-wrapper.sh $VENV/bin/python3 $BASE/scripts/web15rss_fetch.py
+*/30 * * * *   $SCRIPTS/cron-wrapper.sh $VENV/bin/python3 $SCRIPTS/web15rss_fetch.py
 
-*/2 * * * *    $BASE/scripts/cron-wrapper.sh OWM_REQS_PER_RUN=50 $VENV/bin/python3 $BASE/scripts/update_world_wx.py
+*/2 * * * *    $SCRIPTS/cron-wrapper.sh OWM_REQS_PER_RUN=50 $VENV/bin/python3 $SCRIPTS/update_world_wx.py
 
-5 */8 * * *    $BASE/scripts/cron-wrapper.sh $BASE/scripts/gen_contest-calendar.sh
+5 */8 * * *    $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_contest-calendar.sh
 
 # Runs AMSAT Active Satellite Filter and builds TLEs
-0 */2 * * *    $BASE/scripts/cron-wrapper.sh $BASE/scripts/fetch_tle.sh
+0 */2 * * *    $SCRIPTS/cron-wrapper.sh $SCRIPTS/fetch_tle.sh
 
 # Give NOAA time to breathe
-2,17,32,47 * * * * $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/gen_aurora.py
-*/30 * * * *   $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/gen_noaaswx.sh
+2,17,32,47 * * * * $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_aurora.py
+*/30 * * * *   $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_noaaswx.sh
 
 # POTA, SOTA, WWFF
-0 3 * * 1      $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_wwff_cache.pl
-0 4 * * 1,4    $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_sota_cache.pl
-1-59/2 * * * * $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/gen_onta.pl
+0 3 * * 1      $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_wwff_cache.pl
+0 4 * * 1,4    $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_sota_cache.pl
+1-59/2 * * * * $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_onta.pl
 
-1-56/5 * * * * $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/gen_drap.sh
+1-56/5 * * * * $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_drap.sh
 
-20 2 * * *     $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/gen_cty_wt_mod.sh
+20 2 * * *     $SCRIPTS/cron-wrapper.sh $SCRIPTS/gen_cty_wt_mod.sh
 
-*/30 * * * *   $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_all_sdo.sh
+*/30 * * * *   $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_all_sdo.sh
 
 # maps
-10,40 * * * *  $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/kc2g_muf_heatmap.sh
-20 */3 * * *   $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_cloud_maps.sh
-*/5 * * * *    $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_drap_maps.sh
-3,18,33,48 * * * * $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_aurora_maps.sh
-0 2,8,14,20 * * *   $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/update_wx_mb_maps.sh
+10,40 * * * *  $SCRIPTS/cron-wrapper.sh $SCRIPTS/kc2g_muf_heatmap.sh
+20 */3 * * *   $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_cloud_maps.sh
+*/5 * * * *    $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_drap_maps.sh
+3,18,33,48 * * * * $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_aurora_maps.sh
+0 2,8,14,20 * * *   $SCRIPTS/cron-wrapper.sh $SCRIPTS/update_wx_mb_maps.sh
 
-*/30 * * * *   $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/probe_dynamic_endpoints.sh
-*/5 * * * *    $BASE/scripts/cron-wrapper.sh /opt/hamclock-backend/scripts/generate_status_json.sh
+*/30 * * * *   $SCRIPTS/cron-wrapper.sh $SCRIPTS/probe_dynamic_endpoints.sh
+*/5 * * * *    $SCRIPTS/cron-wrapper.sh $SCRIPTS/generate_status_json.sh

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -28,13 +28,13 @@
 
 SHELL=/bin/bash
 BASE=/opt/hamclock-backend
-SCRIPTS=$BASE/scripts
-VENV=$BASE/venv
-VIRTUAL_ENV=$BASE/venv
+SCRIPTS=/opt/hamclock-backend/scripts
+VENV=/opt/hamclock-backend/venv
+VIRTUAL_ENV=/opt/hamclock-backend/venv
 HOME=/var/www
-XDG_CACHE_HOME=$BASE/tmp
-MPLCONFIGDIR=$BASE/tmp/mpl
-PATH=$BASE/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+XDG_CACHE_HOME=/opt/hamclock-backend/tmp
+MPLCONFIGDIR=/opt/hamclock-backend/tmp/mpl
+PATH=/opt/hamclock-backend/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 LC_ALL=C
 LANG=C
 


### PR DESCRIPTION
The crontab wrapper nices everything. If we don't want to nice we can pass the --notnice argument.

In addition pipefile is set for all processes when called by the wrapper.

clean up crontab with more uniform and thorough use of path variables.