### PR TITLE
Support changes to forward user_agent to voacap-service fetchVOACAP endpoints

### DIFF
--- a/ham/HamClock/fetchVOACAP-MUF.pl
+++ b/ham/HamClock/fetchVOACAP-MUF.pl
@@ -88,7 +88,9 @@ my $ua = Mojo::UserAgent->new
     ->request_timeout($TIMEOUT)
     ->max_redirects(0);
 
-my $tx = $ua->build_tx(GET => $url);
+#my $tx = $ua->build_tx(GET => $url);
+my $original_ua = $ENV{HTTP_USER_AGENT} // '';
+my $tx = $ua->build_tx(GET => $url, {'User-Agent' => $original_ua});
 
 # Stream upstream body to stdout chunk-by-chunk. Each syswrite reveals
 # whether the downstream client is still there.

--- a/ham/HamClock/fetchVOACAP-TOA.pl
+++ b/ham/HamClock/fetchVOACAP-TOA.pl
@@ -88,7 +88,9 @@ my $ua = Mojo::UserAgent->new
     ->request_timeout($TIMEOUT)
     ->max_redirects(0);
 
-my $tx = $ua->build_tx(GET => $url);
+#my $tx = $ua->build_tx(GET => $url);
+my $original_ua = $ENV{HTTP_USER_AGENT} // '';
+my $tx = $ua->build_tx(GET => $url, {'User-Agent' => $original_ua});
 
 # Stream upstream body to stdout chunk-by-chunk. Each syswrite reveals
 # whether the downstream client is still there.

--- a/ham/HamClock/fetchVOACAPArea.pl
+++ b/ham/HamClock/fetchVOACAPArea.pl
@@ -88,7 +88,9 @@ my $ua = Mojo::UserAgent->new
     ->request_timeout($TIMEOUT)
     ->max_redirects(0);
 
-my $tx = $ua->build_tx(GET => $url);
+#my $tx = $ua->build_tx(GET => $url);
+my $original_ua = $ENV{HTTP_USER_AGENT} // '';
+my $tx = $ua->build_tx(GET => $url, {'User-Agent' => $original_ua});
 
 # Stream upstream body to stdout chunk-by-chunk. Each syswrite reveals
 # whether the downstream client is still there.


### PR DESCRIPTION
 Changes to be committed:
	modified:   fetchVOACAP-MUF.pl
	modified:   fetchVOACAP-TOA.pl
	modified:   fetchVOACAPArea.pl
When updating voacap-service to process User_Agent, I added some diagnostics and USER_AGENT was replaced in open-hamclock-backend
----
172.21.0.3 - - [13/May/2026:20:30:17 +0000] "GET /fetchVOACAP-TOA.pl?TXLAT=40&TXLNG=-90&MODE=19&MONTH=1&YEAR=2026&UTC=12&WATTS=100&MHZ=21.1&HEIGHT=330&WIDTH=660&TOA=3&PATH=0&ohb-ssn=56 HTTP/1.1" 200 95993 "-" "Mojolicious (Perl)"
2026-05-13 20:30:17,861 INFO APP - dispatching path /fetchVOACAPArea.pl
2026-05-13 20:30:17,861 INFO   environ: HTTP_ACCEPT_ENCODING = gzip
2026-05-13 20:30:17,861 INFO   environ: HTTP_HOST = voacap-service:8080
2026-05-13 20:30:17,861 INFO   environ: HTTP_USER_AGENT = Mojolicious (Perl)
2026-05-13 20:30:17,862 INFO INFO voacapl user_agent: HamClockUA(not HamClock, raw='Mojolicious (Perl)')
----
These changes preserve the USER_AGENT for voacap-service processing, specifically to determine map format needed to generate.
Testing after the changes in this commit using docker cp into open-hamclock-backend container.
----
2026-05-13 20:35:57,740 INFO APP - dispatching path /fetchVOACAPArea.pl
2026-05-13 20:35:57,741 INFO   environ: HTTP_ACCEPT_ENCODING = gzip
2026-05-13 20:35:57,741 INFO   environ: HTTP_HOST = voacap-service:8080
2026-05-13 20:35:57,741 INFO   environ: HTTP_USER_AGENT = HamClock-linux/3.10
2026-05-13 20:35:57,741 INFO INFO voacapl user_agent: HamClockUA(platform=linux, version=3.10)
----