### PR TITLE
Centralize the system message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # .gitignore
 # don't include these files in the git repo
 *.env
+sysmsg.txt
 ohb-maps.tar.zst
 notes/
 .vscode/

--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -590,6 +590,7 @@ docker_compose_reset() {
     get_current_http_port
     get_current_https_port
     get_current_image_tag
+    determine_sysmsg_file
     docker_compose_down || return $RETVAL
     docker_compose_up
 }
@@ -970,6 +971,12 @@ determine_tag() {
     fi
 }
 
+determine_sysmsg_file() {
+    SYSMSG_FILE=$HERE/sysmsg.txt
+    [ ! -e $SYSMSG_FILE ] && touch $SYSMSG_FILE
+    SYSMSG_FILE_MAPPING="- $SYSMSG_FILE:/opt/hamclock-backend/data/sysmsg.txt"
+}
+
 docker_compose_yml() {
     determine_http_port
     determine_https_port
@@ -979,6 +986,7 @@ docker_compose_yml() {
     determine_voacap_service_host
     determine_alpha_install
     determine_host_hostname
+    determine_sysmsg_file
 
     determine_tag || return $?
     IMAGE=$IMAGE_BASE:$TAG
@@ -1013,7 +1021,7 @@ services:
       $HTTPS_PORT_MAPPING
     volumes:
       - ohb-htdocs:/opt/hamclock-backend/htdocs
-      - $HERE/sysmsg.txt:/opt/hamclock-backend/data/sysmsg.txt
+      $SYSMSG_FILE_MAPPING
       $EXTERNAL_HTTP_LOG_MAPPING
       $HTTPS_CERT_MAPPING
     tmpfs:

--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -1013,6 +1013,7 @@ services:
       $HTTPS_PORT_MAPPING
     volumes:
       - ohb-htdocs:/opt/hamclock-backend/htdocs
+      - $HERE/sysmsg.txt:/opt/hamclock-backend/data/sysmsg.txt
       $EXTERNAL_HTTP_LOG_MAPPING
       $HTTPS_CERT_MAPPING
     tmpfs:

--- a/ham/HamClock/sysmsg.pl
+++ b/ham/HamClock/sysmsg.pl
@@ -17,13 +17,29 @@
 
 use strict;
 use warnings;
-use CGI;
+use LWP::UserAgent;
 
-my $cache_dir = "/opt/hamclock-backend/cache";
-my $content = <<EOF;
-This is a test message. Normally empty or blank.
-EOF
+my $alpha = $ENV{ALPHA_INSTALL} // '';
 
-my $q = CGI->new;
-print $q->header('text/plain');
-print $content;
+if ($alpha eq 'true') {
+    # Serve the message from the local data file
+    my $local_msg = '/opt/hamclock-backend/data/sysmsg.txt';
+    print "Content-Type: text/plain\r\n\r\n";
+    if (-f $local_msg && open(my $fh, '<', $local_msg)) {
+        print while <$fh>;
+        close($fh);
+    }
+} else {
+    # Pull (proxy) from the host provided in ALPHA_INSTALL
+    my $host = $alpha || 'ohb.hamclock.app';
+    $host =~ s|^https?://||;
+    my $url = "http://$host/ham/HamClock/sysmsg.pl";
+
+    my $ua = LWP::UserAgent->new(timeout => 5);
+    my $resp = $ua->get($url);
+
+    print "Content-Type: text/plain\r\n\r\n";
+    if ($resp->is_success) {
+        print $resp->decoded_content;
+    }
+}

--- a/lighttpd-conf/50-hamclock.conf
+++ b/lighttpd-conf/50-hamclock.conf
@@ -12,6 +12,7 @@ magnet.attract-response-start-to = (
 cgi.assign = (
   ".pl" => "/usr/bin/perl"
 )
+setenv.add-environment = ( "ALPHA_INSTALL" => env.ALPHA_INSTALL )
 
 # Single mapping for HamClock paths (static + CGI)
 alias.url += (

--- a/lighttpd-conf/53-voacap-cgi-timeouts.conf
+++ b/lighttpd-conf/53-voacap-cgi-timeouts.conf
@@ -14,7 +14,7 @@
 #   Band conditions: subprocess(30s) < nginx(45s) < perl LWP(45s) < lighttpd(300s) < harakiri(300s)
 #   Area / TOA / MUF: subprocess(120s) < nginx(300s) < perl LWP(300s) < lighttpd(300s) < harakiri(300s)
 
-setenv.add-environment = ( "VOACAP_SERVICE_HOST" => env.VOACAP_SERVICE_HOST )
+setenv.add-environment += ( "VOACAP_SERVICE_HOST" => env.VOACAP_SERVICE_HOST )
 
 $HTTP["url"] =~ "^/ham/HamClock/fetch(VOACAPArea|VOACAP-TOA|VOACAP-MUF|BandConditions)\.pl" {
     server.max-read-idle  = 300


### PR DESCRIPTION
Use the alpha server to centralize the message in a multi-server system. Also mount a file from the host into docker so that the file can be modified without going into the container. This also enables the file to be persistent when the container is recreated.