### PR TITLE
Remove dup wspr and fix tmp files

### DIFF
--- a/scripts/fetch_cyclones.py
+++ b/scripts/fetch_cyclones.py
@@ -79,10 +79,12 @@ The storms subdirectory is created automatically if it does not exist.
 import sys
 import os
 import json
+import shutil
 import urllib.request
 import urllib.error
 import datetime
 import argparse
+import tempfile
 import math
 
 # ---------------------------------------------------------------------------
@@ -93,6 +95,7 @@ NHC_CURRENT_STORMS_URL = "https://www.nhc.noaa.gov/CurrentStorms.json"
 
 STORMS_OUTPUT_DIR = "/opt/hamclock-backend/htdocs/ham/HamClock/storms"
 STORMS_OUTPUT_FILE = os.path.join(STORMS_OUTPUT_DIR, "storms.txt")
+TMP_DIR = "/opt/hamclock-backend/tmp"
 
 # ATCF best-track and forecast files -- used for live data and testing
 # Active season: ftp.nhc.noaa.gov/atcf/btk/b{id}.dat (best track, updated in-season)
@@ -588,12 +591,17 @@ def write_storms_file(lines, outfile=STORMS_OUTPUT_FILE):
     outdir = os.path.dirname(outfile)
     os.makedirs(outdir, mode=0o755, exist_ok=True)
 
-    tmpfile = f"{outfile}.tmp"
-    with open(tmpfile, 'w') as f:
-        f.write(body)
-
-    os.chmod(tmpfile, 0o644)
-    os.replace(tmpfile, outfile)
+    os.makedirs(TMP_DIR, exist_ok=True)
+    fd, tmpfile = tempfile.mkstemp(dir=TMP_DIR, prefix="storms", suffix=".tmp")
+    try:
+        with os.fdopen(fd, 'w') as f:
+            f.write(body)
+        shutil.move(tmpfile, outfile)
+        os.chmod(outfile, 0o644)
+    except Exception:
+        if os.path.exists(tmpfile):
+            os.unlink(tmpfile)
+        raise
 
     print(f"Written {len(lines)} lines to {outfile}", file=sys.stderr)
 

--- a/scripts/gen_aurora.py
+++ b/scripts/gen_aurora.py
@@ -31,6 +31,7 @@
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
 import time
@@ -39,6 +40,7 @@ from urllib.request import Request, urlopen
 
 URL = "https://services.swpc.noaa.gov/json/ovation_aurora_latest.json"
 OUT = Path("/opt/hamclock-backend/htdocs/ham/HamClock/aurora/aurora.txt")
+TMP_DIR = Path("/opt/hamclock-backend/tmp")
 
 RESEED_GAP = 12 * 3600
 RESEED_POINTS = 48
@@ -81,16 +83,18 @@ def load_max_value() -> int:
 
 
 def atomic_write_lines(path: Path, lines: list[str]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(
         "w",
         encoding="utf-8",
-        dir=str(path.parent),
+        dir=str(TMP_DIR),
         delete=False,
     ) as tmp:
         tmp.writelines(lines)
         tmp_name = tmp.name
-    os.replace(tmp_name, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(tmp_name, path)
+    os.chmod(path, 0o644)
 
 
 def reseed(bucket_ts: int, value: int) -> None:

--- a/scripts/gen_dxpeditions_spots.py
+++ b/scripts/gen_dxpeditions_spots.py
@@ -43,9 +43,11 @@ Model:
 import re
 import sys
 import time
+import shutil
 import hashlib
 import logging
 import argparse
+import tempfile
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from dataclasses import dataclass
@@ -63,6 +65,7 @@ from lxml import html as lxml_html
 
 OUT_FILE  = Path('/opt/hamclock-backend/htdocs/ham/HamClock/dxpeds/dxpeditions.txt')
 LOCK_FILE = Path('/opt/hamclock-backend/tmp/gen_dxpeditions.lock')
+TMP_DIR   = Path('/opt/hamclock-backend/tmp')
 
 NG3K_URL        = 'https://www.ng3k.com/Misc/adxoplain.html'
 NG3K_URL_OUTPUT = 'http://www.ng3k.com/Misc/adxo.html'
@@ -660,9 +663,12 @@ def write_if_changed(content: str, path: Path) -> bool:
             log.info('Refreshing file timestamp.')
             path.touch()
             return False
-    tmp = path.with_suffix('.tmp')
-    tmp.write_text(content)
-    tmp.replace(path)
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile('w', dir=str(TMP_DIR), delete=False) as tf:
+        tf.write(content)
+        tmp_name = tf.name
+    shutil.move(tmp_name, path)
+    os.chmod(path, 0o644)
     log.info('Wrote %d bytes to %s', len(content), path)
     return True
 

--- a/scripts/kindex_simple.py
+++ b/scripts/kindex_simple.py
@@ -29,6 +29,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 import tempfile
 import time
@@ -37,6 +38,7 @@ import requests
 
 KP_URL  = "https://services.swpc.noaa.gov/products/noaa-planetary-k-index-forecast.json"
 OUTFILE = "/opt/hamclock-backend/htdocs/ham/HamClock/geomag/kindex.txt"
+TMP_DIR = "/opt/hamclock-backend/tmp"
 
 TIMEOUT = 20
 HEADERS = {"User-Agent": "OHB kindex_simple.py"}
@@ -83,20 +85,22 @@ def build_output(records: list[dict]) -> list[float]:
 
 
 def atomic_write_lines(path: str, values: list[float]) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    os.makedirs(TMP_DIR, exist_ok=True)
     payload = "".join(f"{v:.2f}\n" for v in values)
 
     fd, tmp = tempfile.mkstemp(
         prefix=".kindex.",
         suffix=".tmp",
-        dir=os.path.dirname(path),
+        dir=TMP_DIR,
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
             f.write(payload)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(tmp, path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        shutil.move(tmp, path)
+        os.chmod(path, 0o644)
     except Exception:
         try:
             os.unlink(tmp)

--- a/scripts/probe_dynamic_endpoints.sh
+++ b/scripts/probe_dynamic_endpoints.sh
@@ -101,7 +101,6 @@ ENDPOINTS=(
   "psk_reporter|fetchPSKReporter.pl?ofcall=W1AW&maxage=3600|1"
   "wspr.live|fetchWSPR.pl?ofcall=W1AW&maxage=3600|1"
   "rbn|fetchRBN.pl?ofcall=W1AW&maxage=3600|1"
-  "wspr|fetchWSPR.pl?ofcall=W1AW&maxage=3600|1"
   "band_conditions|fetchBandConditions.pl?MODE=19&MONTH=0&YEAR=2026&UTC=12&TXLAT=40&TXLNG=-90&RXLAT=50&RXLNG=10&POW=100&TOA=3&PATH=0|0"
   "voacap_muf|fetchVOACAP-MUF.pl?TXLAT=40&TXLNG=-90&MODE=19&MONTH=1&YEAR=2026&UTC=12&WATTS=100&MHZ=14.1&HEIGHT=330&WIDTH=660&TOA=3&PATH=0|0"
   "voacap_toa|fetchVOACAP-TOA.pl?TXLAT=40&TXLNG=-90&MODE=19&MONTH=1&YEAR=2026&UTC=12&WATTS=100&MHZ=21.1&HEIGHT=330&WIDTH=660&TOA=3&PATH=0|0"

--- a/scripts/swind_simple.py
+++ b/scripts/swind_simple.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import shutil
 import tempfile
 import urllib.request
 from datetime import datetime, timezone
@@ -65,6 +66,7 @@ from typing import List, Tuple
 
 URL = "https://services.swpc.noaa.gov/json/rtsw/rtsw_wind_1m.json"
 OUT = "/opt/hamclock-backend/htdocs/ham/HamClock/solar-wind/swind-24hr.txt"
+TMP_DIR = "/opt/hamclock-backend/tmp"
 
 # 24h at ~1-minute cadence
 KEEP_N = 1440
@@ -179,12 +181,14 @@ def apply_window(samples: List[Tuple[int, float, float]]) -> List[Tuple[int, flo
 
 
 def atomic_write(path: str, lines: List[str]) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=".swind-", dir=os.path.dirname(path))
+    os.makedirs(TMP_DIR, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".swind-", dir=TMP_DIR)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.writelines(lines)
-        os.replace(tmp, path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        shutil.move(tmp, path)
+        os.chmod(path, 0o644)
     except Exception:
         try:
             os.unlink(tmp)

--- a/scripts/update_world_wx.py
+++ b/scripts/update_world_wx.py
@@ -46,6 +46,8 @@ import json
 import os
 import re
 import sys
+import shutil
+import tempfile
 import time
 import warnings
 
@@ -153,14 +155,16 @@ def read_json(path, default=None):
 
 def write_json_atomic(path, obj):
     """Write obj as JSON to path atomically (tmp file + os.replace)."""
-    tmp = path + f".{os.getpid()}.tmp"
+    os.makedirs(TMP_DIR, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=TMP_DIR, prefix="cache", suffix=".tmp")
     try:
-        with open(tmp, "w", encoding="utf-8") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(obj, fh)
-        os.replace(tmp, path)
+        shutil.move(tmp, path)
+        os.chmod(path, 0o644)
     except Exception as exc:
         print(f"WARN: could not write {path}: {exc}", file=sys.stderr)
-        try:
+        if os.path.exists(tmp):
             os.unlink(tmp)
         except OSError:
             pass
@@ -350,11 +354,11 @@ def write_wx_txt(out_path, cache):
     Iterates lon-major (outer LONS, inner LATS) with a blank line between
     lon groups — identical structure to the original Perl output.
     """
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
-    tmp_path = out_path + f".{os.getpid()}.tmp"
+    os.makedirs(TMP_DIR, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=TMP_DIR, prefix="wx", suffix=".tmp")
 
     try:
-        with open(tmp_path, "w", encoding="utf-8") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write("#   lat     lng  temp,C     %hum    mps     dir    mmHg    Wx           TZ\n")
             for lon in LONS:
                 for lat in LATS:
@@ -362,7 +366,9 @@ def write_wx_txt(out_path, cache):
                     r   = cache.get(key, FALLBACK)
                     fh.write(fmt_line(lat, lon, r))
                 fh.write("\n")  # blank line between lon groups
-        os.replace(tmp_path, out_path)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        shutil.move(tmp_path, out_path)
+        os.chmod(out_path, 0o644)
     except Exception as exc:
         print(f"ERROR: could not write {out_path}: {exc}", file=sys.stderr)
         try:

--- a/scripts/web15rss_fetch.py
+++ b/scripts/web15rss_fetch.py
@@ -27,6 +27,7 @@
 import os
 import sys
 import logging
+import shutil
 import tempfile
 from datetime import date, datetime
 
@@ -38,6 +39,7 @@ from bs4 import BeautifulSoup
 # Config
 # ---------------------------------------------------------------------------
 CACHE_DIR = "/opt/hamclock-backend/cache/rss"
+TMP_DIR = "/opt/hamclock-backend/tmp"
 REQUEST_TIMEOUT = 15
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 ARNEWSLINE_MAX = 5
@@ -72,9 +74,9 @@ def write_cache(name: str, lines: list[str], encoding: str | None = None) -> Non
 
     enc = encoding or CACHE_ENCODINGS.get(name, "utf-8")
 
-    os.makedirs(CACHE_DIR, exist_ok=True)
+    os.makedirs(TMP_DIR, exist_ok=True)
     dest = os.path.join(CACHE_DIR, f"{name}.txt")
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=CACHE_DIR, prefix=f"{name}_", suffix=".tmp")
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=TMP_DIR, prefix=f"{name}_", suffix=".tmp")
 
     try:
         with os.fdopen(tmp_fd, "w", encoding=enc, errors="replace", newline="\n") as fh:
@@ -82,7 +84,9 @@ def write_cache(name: str, lines: list[str], encoding: str | None = None) -> Non
             fh.flush()
             os.fsync(fh.fileno())
 
-        os.replace(tmp_path, dest)  # atomic on Linux (same filesystem)
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        shutil.move(tmp_path, dest)
+        os.chmod(dest, 0o644)
         log.info("[%s] Wrote %d lines to cache (%s)", name, len(lines), enc)
 
     except Exception:

--- a/scripts/web15rss_fetch.py
+++ b/scripts/web15rss_fetch.py
@@ -27,7 +27,6 @@
 import os
 import sys
 import logging
-import shutil
 import tempfile
 from datetime import date, datetime
 
@@ -39,7 +38,6 @@ from bs4 import BeautifulSoup
 # Config
 # ---------------------------------------------------------------------------
 CACHE_DIR = "/opt/hamclock-backend/cache/rss"
-TMP_DIR = "/opt/hamclock-backend/tmp"
 REQUEST_TIMEOUT = 15
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 ARNEWSLINE_MAX = 5
@@ -74,9 +72,9 @@ def write_cache(name: str, lines: list[str], encoding: str | None = None) -> Non
 
     enc = encoding or CACHE_ENCODINGS.get(name, "utf-8")
 
-    os.makedirs(TMP_DIR, exist_ok=True)
+    os.makedirs(CACHE_DIR, exist_ok=True)
     dest = os.path.join(CACHE_DIR, f"{name}.txt")
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=TMP_DIR, prefix=f"{name}_", suffix=".tmp")
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=CACHE_DIR, prefix=f"{name}_", suffix=".tmp")
 
     try:
         with os.fdopen(tmp_fd, "w", encoding=enc, errors="replace", newline="\n") as fh:
@@ -84,9 +82,7 @@ def write_cache(name: str, lines: list[str], encoding: str | None = None) -> Non
             fh.flush()
             os.fsync(fh.fileno())
 
-        os.makedirs(CACHE_DIR, exist_ok=True)
-        shutil.move(tmp_path, dest)
-        os.chmod(dest, 0o644)
+        os.replace(tmp_path, dest)  # atomic on Linux (same filesystem)
         log.info("[%s] Wrote %d lines to cache (%s)", name, len(lines), enc)
 
     except Exception:


### PR DESCRIPTION
We accidentally added 2 fetchWSPR checks. There already was one.

Also status is picking up temp files occasionally. Create tmp files in the local tmp/ folder and move into place. python's shutil.move does a copy and unlink to minimize the chance of getting a partial file.