### PR TITLE
Mounting a file requires too much care

### DIFF
--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -1010,9 +1010,17 @@ determine_tag() {
 }
 
 determine_sysmsg_file() {
-    SYSMSG_FILE=$HERE/sysmsg.txt
-    [ ! -e $SYSMSG_FILE ] && touch $SYSMSG_FILE
-    SYSMSG_FILE_MAPPING="- $SYSMSG_FILE:/opt/hamclock-backend/data/sysmsg.txt"
+    SYSMSG_FILE="$HERE/msg/sysmsg.txt"
+    SYSMSG_FILE_PATH="$(dirname "$SYSMSG_FILE")"
+    if [ "$ALPHA_INSTALL" == true ]; then
+        if [ ! -e "$SYSMSG_FILE" ]; then
+            mkdir -p "$SYSMSG_FILE_PATH"
+            touch "$SYSMSG_FILE"
+        fi
+        SYSMSG_FILE_MAPPING="- \"$SYSMSG_FILE_PATH:/opt/hamclock-backend/data/msg\""
+    else
+        SYSMSG_FILE_MAPPING=
+    fi
 }
 
 docker_compose_yml() {

--- a/ham/HamClock/sysmsg.pl
+++ b/ham/HamClock/sysmsg.pl
@@ -23,7 +23,7 @@ my $alpha = $ENV{ALPHA_INSTALL} // '';
 
 if ($alpha eq 'true') {
     # Serve the message from the local data file
-    my $local_msg = '/opt/hamclock-backend/data/sysmsg.txt';
+    my $local_msg = '/opt/hamclock-backend/data/msg/sysmsg.txt';
     print "Content-Type: text/plain\r\n\r\n";
     if (-f $local_msg && open(my $fh, '<', $local_msg)) {
         print while <$fh>;


### PR DESCRIPTION
When a file is mounted in a container the container attaches to the inode. Usually editing a file creates a new one so it isn't mounted anymore. Better to mount a dir.