### PR TITLE
Proxy the same either way

### DIFF
--- a/ham/HamClock/fetchBandConditions.pl
+++ b/ham/HamClock/fetchBandConditions.pl
@@ -25,8 +25,8 @@ use Mojo::IOLoop;
 $SIG{PIPE} = 'IGNORE';
 
 my $host        = $ENV{VOACAP_SERVICE_HOST} || 'voacap-service:8080';
-my $SERVICE_URL = "http://$host";
-my $ENDPOINT    = "$SERVICE_URL/fetchBandConditions";
+my $SERVICE_URL = "http://$host/ham/HamClock";
+my $ENDPOINT    = "$SERVICE_URL/fetchBandConditions.pl";
 
 # Timeout layers (shortest first):
 #   Python subprocess(voacapl) = 30s   (voacap_service.py)

--- a/ham/HamClock/fetchVOACAP-MUF.pl
+++ b/ham/HamClock/fetchVOACAP-MUF.pl
@@ -49,7 +49,7 @@ $SIG{PIPE} = 'IGNORE';
 # —————————————————————————
 
 my $host        = $ENV{VOACAP_SERVICE_HOST} || 'voacap-service:8080';
-my $SERVICE_URL = "http://$host";
+my $SERVICE_URL = "http://$host/ham/HamClock";
 my $ENDPOINT    = "$SERVICE_URL/fetchVOACAP-MUF.pl";
 
 # Hard upper bound on the proxied request. Matches voacap-service's

--- a/ham/HamClock/fetchVOACAP-TOA.pl
+++ b/ham/HamClock/fetchVOACAP-TOA.pl
@@ -49,7 +49,7 @@ $SIG{PIPE} = 'IGNORE';
 # —————————————————————————
 
 my $host        = $ENV{VOACAP_SERVICE_HOST} || 'voacap-service:8080';
-my $SERVICE_URL = "http://$host";
+my $SERVICE_URL = "http://$host/ham/HamClock";
 my $ENDPOINT    = "$SERVICE_URL/fetchVOACAP-TOA.pl";
 
 # Hard upper bound on the proxied request. Matches voacap-service's

--- a/ham/HamClock/fetchVOACAPArea.pl
+++ b/ham/HamClock/fetchVOACAPArea.pl
@@ -49,7 +49,7 @@ $SIG{PIPE} = 'IGNORE';
 # —————————————————————————
 
 my $host        = $ENV{VOACAP_SERVICE_HOST} || 'voacap-service:8080';
-my $SERVICE_URL = "http://$host";
+my $SERVICE_URL = "http://$host/ham/HamClock";
 my $ENDPOINT    = "$SERVICE_URL/fetchVOACAPArea.pl";
 
 # Hard upper bound on the proxied request. Matches voacap-service's


### PR DESCRIPTION
Proxy the voacap endpoints either to the container or to ohb in the same format. We'd like to be able to combine services which means we'll separate the stand-alone voacap out.