### PR TITLE
Improve the summary

### DIFF
--- a/scripts/generate_status_json.sh
+++ b/scripts/generate_status_json.sh
@@ -179,6 +179,54 @@ classify_age() {
 }
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ── Stats Aggregation ────────────────────────────────────────────────────────
+DATA_FRESH=0; DATA_RECENT=0; DATA_AGED=0; DATA_STALE=0; DATA_STATIC=0; DATA_TOTAL=0
+SDO_FRESH=0;  SDO_RECENT=0;  SDO_AGED=0;  SDO_STALE=0;  SDO_STATIC=0;  SDO_TOTAL=0
+MAP_FRESH=0;  MAP_RECENT=0;  MAP_AGED=0;  MAP_STALE=0;  MAP_STATIC=0;  MAP_TOTAL=0
+
+calculate_stats() {
+    local dir="$1"
+    local label="$2"
+    local -n _f=$3; local -n _r=$4; local -n _a=$5; local -n _s=$6; local -n _st=$7; local -n _t=$8
+
+    [ ! -d "$dir" ] && return
+    while IFS= read -r -d '' filepath; do
+        local filename=$(basename "$filepath")
+        [ "$filename" = "ignore" ] && continue
+        _t=$(( _t + 1 ))
+
+        local status_text
+        local use_remote=0
+        if [[ "$label" == "map" && -n "${REMOTE_FILE_MOD[$filename]:-}" ]]; then
+            use_remote=1
+        elif [[ "$filename" == "wwff_spots.json" && ! "$CQGMA_API_KEY" =~ ^GMA- && -n "${REMOTE_FILE_MOD[$filename]:-}" ]]; then
+            use_remote=1
+        fi
+
+        if [ "$use_remote" -eq 1 ]; then
+            status_text="${REMOTE_FILE_STATUS[$filename]}"
+        else
+            local mod_epoch=$(stat -c %Y "$filepath" 2>/dev/null || stat -f %m "$filepath" 2>/dev/null || echo 0)
+            local age_sec=$(( NOW_EPOCH - mod_epoch ))
+            local thresholds
+            thresholds=$(get_thresholds "$label" "$filename")
+            local class_and_text
+            class_and_text=$(classify_age "$age_sec" "$thresholds")
+            status_text="${class_and_text#* }"
+        fi
+
+        case "$status_text" in
+            FRESH)  _f=$(( _f + 1 )) ;;
+            RECENT) _r=$(( _r + 1 )) ;;
+            AGED)   _a=$(( _a + 1 )) ;;
+            STALE)  _s=$(( _s + 1 )) ;;
+            STATIC) _st=$(( _st + 1 )) ;;
+        esac
+    done < <(find "$dir" -maxdepth 1 -type f -print0 2>/dev/null)
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+
 NOW=$(date -u "+%Y-%m-%d %H:%M:%S")
 NOW_EPOCH=$(date -u +%s)
 
@@ -255,6 +303,30 @@ else
     echo "WARNING: $DYNAMIC_SIDECAR not found or not readable. Treating as unavailable." >&2
 fi
 
+for subdir in "${DATA_SUBDIRS[@]}"; do
+    calculate_stats "${DATA_DIR}/${subdir}" "$subdir" DATA_FRESH DATA_RECENT DATA_AGED DATA_STALE DATA_STATIC DATA_TOTAL
+done
+calculate_stats "$SDO_DIR" "SDO" SDO_FRESH SDO_RECENT SDO_AGED SDO_STALE SDO_STATIC SDO_TOTAL
+calculate_stats "$MAPS_DIR" "map" MAP_FRESH MAP_RECENT MAP_AGED MAP_STALE MAP_STATIC MAP_TOTAL
+
+fmt_stat_summary() {
+    local f=$1 r=$2 a=$3 s=$4 st=$5
+    [ "$f" -gt 0 ] && echo -n "<span class='badge ok'>FRESH: $f</span> "
+    [ "$r" -gt 0 ] && echo -n "<span class='badge warn'>RECENT: $r</span> "
+    [ "$a" -gt 0 ] && echo -n "<span class='badge aged'>AGED: $a</span> "
+    [ "$s" -gt 0 ] && echo -n "<span class='badge stale'>STALE: $s</span> "
+    [ "$st" -gt 0 ] && echo -n "<span class='badge static'>STATIC: $st</span> "
+}
+
+fmt_dyn_summary() {
+    local active=$1 idle=$2 empty=$3 timeout=$4 failed=$5
+    [ "$active" -gt 0 ]  && echo -n "<span class='badge ok'>ACTIVE: $active</span> "
+    [ "$idle" -gt 0 ]    && echo -n "<span class='badge static'>IDLE: $idle</span> "
+    [ "$empty" -gt 0 ]   && echo -n "<span class='badge warn'>EMPTY: $empty</span> "
+    [ "$timeout" -gt 0 ] && echo -n "<span class='badge aged'>TIMEOUT: $timeout</span> "
+    [ "$failed" -gt 0 ]  && echo -n "<span class='badge stale'>FAILED: $failed</span> "
+}
+
 dyn_badge_class() { # This function is fine as is, it just maps states to CSS classes
     case "$1" in
         OK)       echo "ok" ;;
@@ -301,8 +373,8 @@ emit_file_row() {
                  || date -u -r "$mod_epoch" "+%Y-%m-%d %H:%M:%S" 2>/dev/null)
         age_sec=$(( NOW_EPOCH - mod_epoch ))
         class_text=$(classify_age "$age_sec" "$(get_thresholds "$label" "$filename")")
-        status_class=$(awk '{print $1}' <<< "$class_text")
-        status_text=$(awk '{print $2}' <<< "$class_text")
+        status_class="${class_text%% *}"
+        status_text="${class_text#* }"
     fi
 
     local age_min=$(( age_sec / 60 ))
@@ -387,17 +459,6 @@ build_dynamic_rows() {
     ' "$DYNAMIC_SIDECAR"
 }
 
-# ── File counters ────────────────────────────────────────────────────────────
-count_data_files() {
-    local total=0
-    for subdir in "${DATA_SUBDIRS[@]}"; do
-        local n
-        n=$(find "${DATA_DIR}/${subdir}" -maxdepth 1 -type f 2>/dev/null | wc -l)
-        total=$(( total + n ))
-    done
-    echo "$total"
-}
-
 # ── JSON builder ─────────────────────────────────────────────────────────────
 # Args: $1=directory  $2=category-label  $3=nameref to first-entry flag
 build_json_entries() {
@@ -428,10 +489,12 @@ build_json_entries() {
             status_text="${REMOTE_FILE_STATUS[$filename]}"
         else
             mod_epoch=$(stat -c %Y "$filepath" 2>/dev/null || stat -f %m "$filepath" 2>/dev/null || echo 0)
-            mod_human=$(date -u -d "@$mod_epoch" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
-                     || date -u -r "$mod_epoch"   "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+            mod_human=$(date -u -d "@$mod_epoch" "+%Y-%m-%d %H:%M:%S" 2>/dev/null \
+                     || date -u -r "$mod_epoch" "+%Y-%m-%d %H:%M:%S" 2>/dev/null)
             age_sec=$(( NOW_EPOCH - mod_epoch ))
-            status_text=$(classify_age "$age_sec" "$(get_thresholds "$label" "$filename")" | awk '{print $2}')
+            local class_and_text
+            class_and_text=$(classify_age "$age_sec" "$(get_thresholds "$label" "$filename")")
+            status_text="${class_and_text#* }"
         fi
 
         local safe_name safe_label
@@ -461,15 +524,15 @@ build_json() {
         printf '  "hostname": "%s",\n'           "$HOST_HOSTNAME"
         printf '  "public_ip": "%s",\n'          "$PUBLIC_IP"
         printf '  "summary": {\n'
-        printf '    "data_product_files": %d,\n' "$DATA_COUNT"
-        printf '    "sdo_files": %d,\n'          "$SDO_COUNT"
-        printf '    "map_files": %d,\n'          "$MAPS_COUNT"
+        printf '    "data_product_files": %d,\n' "$DATA_TOTAL"
+        printf '    "sdo_files": %d,\n'          "$SDO_TOTAL"
+        printf '    "map_files": %d,\n'          "$MAP_TOTAL"
         printf '    "dynamic_endpoints": %d,\n'  "$DYN_TOTAL"
         printf '    "dynamic_active": %d,\n'     "$DYN_ACTIVE"
         printf '    "dynamic_idle": %d,\n'       "$DYN_IDLE"
         printf '    "dynamic_healthy": %d,\n'    "$DYN_HEALTHY"
         printf '    "dynamic_count_24h": %d,\n'  "$DYN_COUNT_24H"
-        printf '    "total_files": %d\n'         "$(( DATA_COUNT + SDO_COUNT + MAPS_COUNT ))"
+        printf '    "total_files": %d\n'         "$(( DATA_TOTAL + SDO_TOTAL + MAP_TOTAL ))"
         printf '  },\n'
 
         # Inline the full dynamic sidecar (or null if missing) so consumers
@@ -493,11 +556,6 @@ build_json() {
         printf '}\n'
     } > "$OUTPUT_JSON"
 }
-
-# ── Counts ───────────────────────────────────────────────────────────────────
-DATA_COUNT=$(count_data_files)
-SDO_COUNT=$(find "$SDO_DIR"  -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
-MAPS_COUNT=$(find "$MAPS_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
 
 # ── Write HTML ───────────────────────────────────────────────────────────────
 {
@@ -613,12 +671,24 @@ cat << HTML_HEAD
     /* ── Legend ── */
     .legend {
       display: flex;
-      gap: 12px;
+      flex-direction: column;
+      gap: 10px;
       padding: 10px 24px;
       background: #f0ede8;
       border-bottom: 1px solid var(--border);
+    }
+    .legend-group {
+      display: flex;
       flex-wrap: wrap;
+      gap: 12px;
       align-items: center;
+    }
+    .legend-label {
+      font-size: 0.63rem;
+      color: var(--muted);
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      min-width: 65px;
     }
     .legend-item { display: flex; align-items: center; gap: 5px; font-size: 0.65rem; color: var(--muted); }
 
@@ -646,6 +716,23 @@ cat << HTML_HEAD
       text-overflow: ellipsis;
       max-width: 40vw;
     }
+
+    .summary-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .summary-row-label {
+      font-size: 0.7rem;
+      color: var(--muted);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      flex-basis: 140px;
+      flex-shrink: 0;
+    }
+
     .dynamic-summary {
       margin-bottom: 10px;
       font-size: 0.78rem;
@@ -732,6 +819,16 @@ cat << HTML_HEAD
       th.col-timestamp, td.timestamp { display: none; }
       td.age { white-space: normal; }
       th, td { padding: 6px 8px; }
+
+      .summary-row-label {
+        flex-basis: 100%;
+        margin-bottom: -4px;
+      }
+
+      .legend-label {
+        flex-basis: 100%;
+        margin-bottom: -2px;
+      }
     }
     @media (max-width: 380px) {
       .callsign { font-size: 1.15rem; }
@@ -762,15 +859,15 @@ cat << HTML_HEAD
 <div class="summary">
   <div class="summary-item">
     <span class="summary-label">Data Product Files</span>
-    <span class="summary-value">${DATA_COUNT}</span>
+    <span class="summary-value">${DATA_TOTAL}</span>
   </div>
   <div class="summary-item">
     <span class="summary-label">SDO Files</span>
-    <span class="summary-value">${SDO_COUNT}</span>
+    <span class="summary-value">${SDO_TOTAL}</span>
   </div>
   <div class="summary-item">
     <span class="summary-label">Map Files</span>
-    <span class="summary-value">${MAPS_COUNT}</span>
+    <span class="summary-value">${MAP_TOTAL}</span>
   </div>
   <div class="summary-item">
     <span class="summary-label">Dynamic Endpoints</span>
@@ -783,12 +880,48 @@ cat << HTML_HEAD
 </div>
 
 <div class="legend">
-  <span style="font-size:0.63rem;color:var(--muted);margin-right:2px">STATUS:</span>
-  <div class="legend-item"><span class="badge ok">FRESH</span> within normal update window</div>
-  <div class="legend-item"><span class="badge warn">RECENT</span> slightly overdue</div>
-  <div class="legend-item"><span class="badge aged">AGED</span> significantly overdue</div>
-  <div class="legend-item"><span class="badge stale">STALE</span> may need attention</div>
-  <div class="legend-item"><span class="badge static">STATIC</span> intentionally fixed</div>
+  <div class="legend-group">
+    <span class="legend-label">DYNAMIC:</span>
+    <div class="legend-item"><span class="badge ok">ACTIVE</span> data ok</div>
+    <div class="legend-item"><span class="badge warn">EMPTY</span> no data</div>
+    <div class="legend-item"><span class="badge static">IDLE</span> working/no spots</div>
+    <div class="legend-item"><span class="badge aged">TIMEOUT</span> connection lost</div>
+    <div class="legend-item"><span class="badge stale">FAILED</span> error</div>
+  </div>
+  <div class="legend-group">
+    <span class="legend-label">FILES:</span>
+    <div class="legend-item"><span class="badge ok">FRESH</span> updated</div>
+    <div class="legend-item"><span class="badge warn">RECENT</span> late</div>
+    <div class="legend-item"><span class="badge aged">AGED</span> old</div>
+    <div class="legend-item"><span class="badge stale">STALE</span> stalled</div>
+    <div class="legend-item"><span class="badge static">STATIC</span> baseline</div>
+  </div>
+</div>
+
+<!-- Summary -->
+<div class="section" style="background: var(--panel);">
+  <div class="section-header">
+    <div class="section-icon"></div>
+    <span class="section-title">Summary</span>
+  </div>
+  <div style="display: flex; flex-direction: column; gap: 12px; margin-bottom: 5px;">
+    <div class="summary-row">
+      <span class="summary-row-label">Dynamic:</span>
+      $(fmt_dyn_summary "$DYN_ACTIVE" "$DYN_IDLE" "$DYN_EMPTY" "$DYN_TIMEOUT" "$DYN_FAILED")
+    </div>
+    <div class="summary-row">
+      <span class="summary-row-label">Data Products:</span>
+      $(fmt_stat_summary "$DATA_FRESH" "$DATA_RECENT" "$DATA_AGED" "$DATA_STALE" "$DATA_STATIC")
+    </div>
+    <div class="summary-row">
+      <span class="summary-row-label">SDO:</span>
+      $(fmt_stat_summary "$SDO_FRESH" "$SDO_RECENT" "$SDO_AGED" "$SDO_STALE" "$SDO_STATIC")
+    </div>
+    <div class="summary-row">
+      <span class="summary-row-label">Maps:</span>
+      $(fmt_stat_summary "$MAP_FRESH" "$MAP_RECENT" "$MAP_AGED" "$MAP_STALE" "$MAP_STATIC")
+    </div>
+  </div>
 </div>
 
 <!-- Dynamic Endpoints -->
@@ -796,12 +929,8 @@ cat << HTML_HEAD
   <div class="section-header">
     <div class="section-icon dynamic-icon"></div>
     <span class="section-title">Dynamic Endpoints</span>
-    <span class="section-path">probe every 30 min · last run ${DYN_GENERATED:-never}</span>
+    <span class="section-path">probe results from ${DYN_GENERATED:-never}</span>
   </div>
-  <p class="dynamic-summary">
-    Overall: <span class="badge $(dyn_badge_class "$DYN_OVERALL")">${DYN_OVERALL}</span>
-    &nbsp;·&nbsp; ${DYN_HEALTHY}/${DYN_TOTAL} healthy (${DYN_ACTIVE} active$( [ "$DYN_IDLE"    -gt 0 ] && echo ", ${DYN_IDLE} idle" ))$( [ "$DYN_EMPTY"   -gt 0 ] && echo " · ${DYN_EMPTY} empty" )$( [ "$DYN_FAILED"  -gt 0 ] && echo " · ${DYN_FAILED} failed" )$( [ "$DYN_TIMEOUT" -gt 0 ] && echo " · ${DYN_TIMEOUT} timeout" )
-  </p>
   <table>
     <thead>
       <tr>


### PR DESCRIPTION
The status page only had a summary for dynamic endpoints. Modified to have a summary section the top covering all the detailed sections.