### PR TITLE
wx could be up to 3 mins

### DIFF
--- a/scripts/status_settings.conf
+++ b/scripts/status_settings.conf
@@ -1,7 +1,7 @@
 # Per-category/file thresholds (seconds)
 # Category/Pattern       Fresh   Recent  Aged
 # -------------------------------------------
-THRESH_BZ_ONTA_WX="180 360 1800"           # 3m 6m 30m
+THRESH_BZ_ONTA_WX="240 480 1800"           # 4m 8m 30m
 THRESH_DRAP_WIND="360 900 3600"            # 6m 15m 1h
 THRESH_XRAY="300 720 3600"                 # 5m 12m 1h
 THRESH_AURORA="1200 2700 10800"            # 20m 45m 3h


### PR DESCRIPTION
wx runs ever 2 mins and takes a minute to run. It seems pretty frequent that it reports "recent". Make the limit 4 mins instead. ONTA and BZ could be ok with 3 mins but it's close enough to just change the threashold and not split them out.