### PR TITLE
Ignore unknown parameters.

### DIFF
--- a/ham/HamClock/version.pl
+++ b/ham/HamClock/version.pl
@@ -32,6 +32,10 @@ if (scalar @params == 1 && $params[0] eq 'keywords') {
 }
 
 @params = grep { $_ ne '' } @params;
+
+# Ignore unknown parameters by filtering to only keep known ones (case-insensitive)
+@params = grep { /^open-hamclock-backend$/i || /^hamclock$/i } @params;
+
 my $has_ohb = grep { /^open-hamclock-backend$/i } @params;
 my $has_hc  = grep { /^hamclock$/i } @params;
 


### PR DESCRIPTION
I guess CSI didn't pay attention to parameters. Not surprising since they didn't use them. So we'll strip unkown parameters, ignore and then enforce parameter rules. At the moment we only need to enforce 1 known parameter at a time.