### PR TITLE
Cron wrapper nice broken

### DIFF
--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # Usage: ./cron-wrapper.sh [--notnice] VAR=val /path/to/bin /path/to/script.py
 
-# 1. Identify the last argument to use as the log filename
+# 1. Handle optional flag first and clean it from arguments
+CMD_PREFIX=()
+if [ "$1" = "--notnice" ]; then
+    shift
+else
+    # Store prefix as an array to safely handle spaces
+    CMD_PREFIX=(nice -n 19 ionice -c 2 -n 7)
+fi
+
+# 2. Identify the last argument to use as the log filename
 FOR_NAME="${@: -1}"
 SCRIPT_NAME=$(basename "$FOR_NAME" | sed 's/\.[^.]*$//')
 LOG_DIR="/opt/hamclock-backend/logs"
@@ -10,31 +19,25 @@ LOCK_FILE="/tmp/${SCRIPT_NAME}.lock"
 
 mkdir -p "$LOG_DIR"
 
-# Set up the priority prefix
-CMD_PREFIX=""
-if [ "$1" == "--notnice" ]; then
-    CMD_PREFIX="nice -n 19 ionice -c 2 -n 7"
-    shift
-fi
-
-# 2. Locking Mechanism
+# 3. Locking Mechanism
 exec 200>"$LOCK_FILE"
 if ! flock -n 200; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $SCRIPT_NAME is already running. Exiting." >> "$LOG_FILE"
     exit 1
 fi
 
-# 3. Execution with full arguments
+# 4. Execution with full arguments
 START_TIME=$(date +%s)
 echo "------------------------------------------------------------" >> "$LOG_FILE"
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] START: $@" >> "$LOG_FILE"
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] START: $*" >> "$LOG_FILE"
 
-# Run the command with priorities and forced shell safety options
-# We use 'bash -euo pipefail -c' to wrap the eval target
-eval "$CMD_PREFIX bash -euo pipefail -c \"$*\"" >> "$LOG_FILE" 2>&1
+# Use 'env' to guarantee that inline assignments (like VAR=val) are processed 
+# correctly regardless of whether nice/ionice prefixes them. 
+# We wrap "$@" in the execution to preserve spaces and arguments safely without eval.
+"${CMD_PREFIX[@]}" env "$@" >> "$LOG_FILE" 2>&1
 EXIT_CODE=$?
 
-# 4. Metrics
+# 5. Metrics
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] END: Exit Code $EXIT_CODE" >> "$LOG_FILE"


### PR DESCRIPTION
Fix cron wrapper was implementing nice backwards so basically it wasn't being used. And then we discovered it wouldn't take inline env arguments.