### PR TITLE
Migrate all refrences to new home

### DIFF
--- a/ANNOUNCEMENTS.md
+++ b/ANNOUNCEMENTS.md
@@ -5,12 +5,12 @@ The original home for OHB (Open Hamclock Backend) has migrated to this repo. You
 
 If you are running a version from before the migration, You'll need to jumpstart yourself.
 
-For the docker install, download the latest manage-ohb-docker.sh utility from [Releases](https://github.com/komacke/open-hamclock-backend/releases/latest). Make it executable and simply run an upgrade like before.
+For the docker install, download the latest manage-ohb-docker.sh utility from [Releases](https://github.com/openhamclock/open-hamclock-backend/releases/latest). Make it executable and simply run an upgrade like before.
 
 If you have a git checkout you need to update your origin like this:
 ```
 # for an https clone:
-git remote set-url origin https://github.com/komacke/open-hamclock-backend.git
+git remote set-url origin https://github.com/openhamclock/open-hamclock-backend.git
 # for an ssh clone:
-git remote set-url origin git@github.com:komacke/open-hamclock-backend.git
+git remote set-url origin git@github.com:openhamclock/open-hamclock-backend.git
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,7 @@ Because of recent changes to depend on other docker containers, we recommend the
 
 ```bash
    # Confirmed working in aws t3-micro Ubuntu 24.x LTS instance
-   wget -O install_ohb.sh https://raw.githubusercontent.com/komacke/open-hamclock-backend/refs/heads/main/aws/install_ohb.sh
+   wget -O install_ohb.sh https://raw.githubusercontent.com/openhamclock/open-hamclock-backend/refs/heads/main/aws/install_ohb.sh
    chmod +x install_ohb.sh
    sudo ./install_ohb.sh
 ```

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,66 +4,66 @@ OHB is and always will be free to use and download.
 
 OHB serves data from its **own internal services**, not from Clear Sky Institute.
 
-Each supporting file type has a data generation script. These scripts operate on a schedule that is defined in a [crontab](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/crontab). The crontab has been specifically tuned to match as close as possible the original ClearSkyInstitute data generation times and be friendly to CPU/MEM on the host. 
+Each supporting file type has a data generation script. These scripts operate on a schedule that is defined in a [crontab](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/crontab). The crontab has been specifically tuned to match as close as possible the original ClearSkyInstitute data generation times and be friendly to CPU/MEM on the host. 
 
-Installers are used to setup, configure and install OHB. We recommend the container-based install as the simplest path go get OHB up and running. See here for [install steps](https://github.com/komacke/open-hamclock-backend/blob/main/INSTALL.md)
+Installers are used to setup, configure and install OHB. We recommend the container-based install as the simplest path go get OHB up and running. See here for [install steps](https://github.com/openhamclock/open-hamclock-backend/blob/main/INSTALL.md)
 
 ### Dynamic Text Files
-These are replaced dynamically in the background on the target host per the baselined [crontab](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/crontab).
+These are replaced dynamically in the background on the target host per the baselined [crontab](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/crontab).
 
-- [x] [Bz/Bz.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/bz_simple.py) - Bz pane
-- [x] [aurora/aurora.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_aurora.sh) - Aurora pane
-- [x] [xray/xray.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/xray_simple.py) - GOES 16 X-Ray pane
-- [x] [worldwx/wx.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/update_world_wx.pl) - weather display on map hover
-- [x] [esats/esats.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/fetch_tle.sh) - supports satellite list under DX
-- [x] [solarflux/solarflux-history.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_solarflux-history.sh) - supports solar flux history display when clicking solar flux pane
-- [x] [ssn/ssn-history.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_ssn_history.pl) - supports sun spot number history display when clicking sun spot number pane 
-- [x] [solar-flux/solarflux-99.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/flux_simple.py) - supports solar flux pane
-- [x] [geomag/kindex.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/kindex_simple.py) - supports planetary kp pane
-- [x] [dst/dst.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/dst_simple.py) - supports disturbances pane
-- [x] [drap/stats.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_drap.sh) - supports drap pane
-- [x] [solar-wind/swind-24hr.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/swind_simple.py) - supports solar wind pane
-- [x] [ssn/ssn-31.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/ssn_simple.py) - supports (smoothed) sunspot number pane
-- [x] [ONTA/onta.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_onta.pl) - generates OTA spots (POTA, SOTA, WWFF) on schedule per crontab
-- [x] [contests/contests311.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_contest-calendar.sh) - generates list of recent contests for contests pane
-- [x] [dxpeds/dxpeditions.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_dxpeditions_spots.py) - generates list of dxpeds for dxpeds pane
-- [x] [NOAASpaceWX/noaaswx.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_noaaswx.sh) - generates NOAA Space Wx metrics for NOAA Space Wx pane
-- [x] [cty/cty_wt_mod-ll-dxcc.txt](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/gen_cty_wt_mod.sh) - used to correlate spots for DXCC
+- [x] [Bz/Bz.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/bz_simple.py) - Bz pane
+- [x] [aurora/aurora.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_aurora.sh) - Aurora pane
+- [x] [xray/xray.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/xray_simple.py) - GOES 16 X-Ray pane
+- [x] [worldwx/wx.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/update_world_wx.pl) - weather display on map hover
+- [x] [esats/esats.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/fetch_tle.sh) - supports satellite list under DX
+- [x] [solarflux/solarflux-history.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_solarflux-history.sh) - supports solar flux history display when clicking solar flux pane
+- [x] [ssn/ssn-history.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_ssn_history.pl) - supports sun spot number history display when clicking sun spot number pane 
+- [x] [solar-flux/solarflux-99.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/flux_simple.py) - supports solar flux pane
+- [x] [geomag/kindex.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/kindex_simple.py) - supports planetary kp pane
+- [x] [dst/dst.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/dst_simple.py) - supports disturbances pane
+- [x] [drap/stats.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_drap.sh) - supports drap pane
+- [x] [solar-wind/swind-24hr.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/swind_simple.py) - supports solar wind pane
+- [x] [ssn/ssn-31.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/ssn_simple.py) - supports (smoothed) sunspot number pane
+- [x] [ONTA/onta.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_onta.pl) - generates OTA spots (POTA, SOTA, WWFF) on schedule per crontab
+- [x] [contests/contests311.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_contest-calendar.sh) - generates list of recent contests for contests pane
+- [x] [dxpeds/dxpeditions.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_dxpeditions_spots.py) - generates list of dxpeds for dxpeds pane
+- [x] [NOAASpaceWX/noaaswx.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_noaaswx.sh) - generates NOAA Space Wx metrics for NOAA Space Wx pane
+- [x] [cty/cty_wt_mod-ll-dxcc.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/gen_cty_wt_mod.sh) - used to correlate spots for DXCC
       
 ### Dynamic Map Files
 Note: Anything under maps/ is considered a "Core Map" in HamClock
 
-These are replaced dynamically in the background on the target host per the baselined [crontab](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/crontab).
+These are replaced dynamically in the background on the target host per the baselined [crontab](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/crontab).
 
-- [x] [maps/Clouds*](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/update_cloud_maps.sh) - Clouds map display
+- [x] [maps/Clouds*](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/update_cloud_maps.sh) - Clouds map display
 - [x] maps/Countries* - copied from CSI and hosted locally; no need to regenerate
-- [x] [maps/Wx-mB*](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/update_wx_mb_maps.sh) - Weather map display (millibar)
-- [x] [maps/Wx-in*](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/update_wx_mb_maps.sh) - Weather map display (inches)
-- [x] [maps/Aurora](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/update_aurora_maps.sh) - Aurora map display
-- [x] [maps/DRAP*](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/update_drap_maps.sh) - DRAP map display
-- [x] [maps/MUF-RT*](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/kc2g_muf_heatmap.sh) - MUF RT display based on kc2g propagation map engine
+- [x] [maps/Wx-mB*](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/update_wx_mb_maps.sh) - Weather map display (millibar)
+- [x] [maps/Wx-in*](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/update_wx_mb_maps.sh) - Weather map display (inches)
+- [x] [maps/Aurora](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/update_aurora_maps.sh) - Aurora map display
+- [x] [maps/DRAP*](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/update_drap_maps.sh) - DRAP map display
+- [x] [maps/MUF-RT*](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/kc2g_muf_heatmap.sh) - MUF RT display based on kc2g propagation map engine
 - [x] maps/Terrain* - copied from CSI and hosted locally; no need to regenerate; Terrain map display
-- [x] [SDO/*](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/update_all_sdo.sh) - images of the Sun for the SDO pane
+- [x] [SDO/*](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/update_all_sdo.sh) - images of the Sun for the SDO pane
 
 ### Dynamic Web Endpoints
 These are endpoints that dynamically return data based on query parameters to the Perl scripts. Query parameters can be 0..Many.
 
-- [x] [ham/HamClock/RSS/web15rss.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/RSS/web15rss.pl) and this [job](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/web15rss_fetch.py) makes the file
-- [x] [ham/HamClock/version.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/version.pl)
-- [x] [ham/HamClock/wx.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/wx.pl)
-- [x] [ham/HamClock/fetchIPGeoloc.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchIPGeoloc.pl) - requires free tier 1000 req per day account and API key
-- [x] [ham/HamClock/fetchBandConditions.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchBandConditions.pl) - implemented in a separate container service on same host
-- [x] [ham/HamClock/fetchVOACAPArea.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchVOACAPArea.pl) - implemented in a separate container service on same host
-- [x] [ham/HamClock/fetchVOACAP-MUF.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchVOACAP-MUF.pl) - implemented in a separate container service on same host
-- [x] [ham/HamClock/fetchVOACAP-TOA.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchVOACAP-TOA.pl) - implemented in a separate container service on same host
-- [x] [ham/HamClock/fetchPSKReporter.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchPSKReporter.pl) 
-- [x] [ham/HamClock/fetchWSPR.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchWSPR.pl)
-- [x] [ham/HamClock/fetchRBN.pl](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/fetchRBN.pl)
+- [x] [ham/HamClock/RSS/web15rss.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/RSS/web15rss.pl) and this [job](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/web15rss_fetch.py) makes the file
+- [x] [ham/HamClock/version.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/version.pl)
+- [x] [ham/HamClock/wx.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/wx.pl)
+- [x] [ham/HamClock/fetchIPGeoloc.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchIPGeoloc.pl) - requires free tier 1000 req per day account and API key
+- [x] [ham/HamClock/fetchBandConditions.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchBandConditions.pl) - implemented in a separate container service on same host
+- [x] [ham/HamClock/fetchVOACAPArea.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchVOACAPArea.pl) - implemented in a separate container service on same host
+- [x] [ham/HamClock/fetchVOACAP-MUF.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchVOACAP-MUF.pl) - implemented in a separate container service on same host
+- [x] [ham/HamClock/fetchVOACAP-TOA.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchVOACAP-TOA.pl) - implemented in a separate container service on same host
+- [x] [ham/HamClock/fetchPSKReporter.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchPSKReporter.pl) 
+- [x] [ham/HamClock/fetchWSPR.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchWSPR.pl)
+- [x] [ham/HamClock/fetchRBN.pl](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/fetchRBN.pl)
 
 ### Static Files
 These files never change or are unlikely to need change any time soon.
-- [x] [ham/HamClock/cities2.txt](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/cities2.txt) - we did not update this file as it appears to require no change
-- [x] [ham/HamClock/NOAASpaceWx/rank2_coeffs.txt](https://github.com/komacke/open-hamclock-backend/blob/main/ham/HamClock/NOAASpaceWX/rank2_coeffs.txt) - we did not update this file as it appears to require no change
+- [x] [ham/HamClock/cities2.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/cities2.txt) - we did not update this file as it appears to require no change
+- [x] [ham/HamClock/NOAASpaceWx/rank2_coeffs.txt](https://github.com/openhamclock/open-hamclock-backend/blob/main/ham/HamClock/NOAASpaceWX/rank2_coeffs.txt) - we did not update this file as it appears to require no change
 
 ### HamClock Upgrades
 HamClocks check with the backend for new HamClock versions. When available they attempt to pull the source zip file from the backend to upgrade themselves.
@@ -92,7 +92,7 @@ ESP8266-based devices use an older API (some URLs are different) and need a bina
 - [x] DRAP data generation, pull and display
 - [x] Planetary Kp data generation, pull and display
 - [x] Solar flux + history data generation, pull and display
-- [x] Amateur Satellites data generation, pull and display + [active AMSAT status satellite filter](https://github.com/komacke/open-hamclock-backend/blob/main/scripts/filter_amsat_active.pl)
+- [x] Amateur Satellites data generation, pull and display + [active AMSAT status satellite filter](https://github.com/openhamclock/open-hamclock-backend/blob/main/scripts/filter_amsat_active.pl)
 - [x] PSK Reporter WSPR request and display
 - [x] PSK Reporter Spots request and display (MQTT based - FAST)
 - [x] VOACAP DE DX (uses new docker container)

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -5,7 +5,7 @@ Because of recent changes to depend on other docker containers, we recommend the
 ### Install in a container with Docker
 Download the manager utility that masks all the Docker details. Visit the releases page:
 
-👉 [Releases](https://github.com/komacke/open-hamclock-backend/releases/latest)
+👉 [Releases](https://github.com/openhamclock/open-hamclock-backend/releases/latest)
 and download the asset: **Manage Docker installs**.
 
 Make it executable:
@@ -26,7 +26,7 @@ Full docker installation details:
 Clone and run the installer:
 
 ```bash
-git clone https://github.com/komacke/open-hamclock-backend.git
+git clone https://github.com/openhamclock/open-hamclock-backend.git
 cd open-hamclock-backend
 sudo bash install_ohb.sh --size <desired size list>
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All we ask is if you fork OHB that you clearly list what parts of OHB you re-use
 ## 🤝 Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-<https://github.com/komacke/open-hamclock-backend/issues>
+<https://github.com/openhamclock/open-hamclock-backend/issues>
 
 ## 📄 Disclaimer 👉 [Disclaimer](./DISCLAIMER.md)
 
@@ -73,5 +73,5 @@ Bug reports and pull requests are welcome on GitHub at
 * Many appliances available for sale, with HamClock pre-installed and automatically maintained
 * Open Hamclock Backend project
     * <https://ohb.works/> - main site
-    * <https://github.com/komacke/open-hamclock-backend> - source
+    * <https://github.com/openhamclock/open-hamclock-backend> - source
 * [hamclock.com](https://hamclock.com) backend

--- a/aws/install_ohb.sh
+++ b/aws/install_ohb.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REPO="https://github.com/komacke/open-hamclock-backend"
+REPO="https://github.com/openhamclock/open-hamclock-backend"
 BASE="/opt/hamclock-backend"
 VENV="$BASE/venv"
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,22 +72,22 @@ Either get the source tree from GitHub or download the manage-ohb-docker.sh scri
 ### option 1: download the manager:
 Find the tag you want from git:
 ```
-https://github.com/komacke/open-hamclock-backend/tags
+https://github.com/openhamclock/open-hamclock-backend/tags
 ```
 Navigate into the tag, download from ```Manage Docker Installs``` which will get you a file named: ```manage-ohb-docker-<version>.sh```. Rename it and make it executable. Using curl might work like this for v1.0:
 ```
-curl -sLO https://github.com/komacke/open-hamclock-backend/releases/download/v1.0/manage-ohb-docker-v1.0.sh
+curl -sLO https://github.com/openhamclock/open-hamclock-backend/releases/download/v1.0/manage-ohb-docker-v1.0.sh
 mv manage-ohb-docker-v1.0.sh manage-ohb-docker.sh 
 chmod +x manage-ohb-docker.sh
 ```
 Plug in the version you downloaded for v1.0 in this example.
 
 ### option 2: get the GitHub source tree
-The git clone command below should have the right URL but you can check it by visiting https://github.com/komacke/open-hamclock-backend, click on the green "Code" button and copy the https url.
+The git clone command below should have the right URL but you can check it by visiting https://github.com/openhamclock/open-hamclock-backend, click on the green "Code" button and copy the https url.
 
 On your computer, clone the repository:
 ```
-git clone https://github.com/komacke/open-hamclock-backend.git
+git clone https://github.com/openhamclock/open-hamclock-backend.git
 ```
 
 Go into the project's docker directory:
@@ -172,7 +172,7 @@ If it shows the latest version at the end, then use it to upgrade OHB:
 Get the latest manager utility and run the manager utility with 'upgrade' command. Like install, it defaults to the current version, or falls back to latest. If the default version isn't what you want, provide the -t option.
 ```
 # Get the version you want. Let's assume it's version: <version>
-curl -sL -o manage-ohb-docker.sh https://github.com/komacke/open-hamclock-backend/releases/download/<version>/manage-ohb-docker-<version>.sh
+curl -sL -o manage-ohb-docker.sh https://github.com/openhamclock/open-hamclock-backend/releases/download/<version>/manage-ohb-docker-<version>.sh
 
 # Make it executable and double check:
 chmod +x manage-ohb-docker.sh

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Variables to set
-GIT_REPO=https://github.com/komacke/open-hamclock-backend
+GIT_REPO=https://github.com/openhamclock/open-hamclock-backend
 IMAGE_BASE=komacke/open-hamclock-backend
 VOACAP_VERSION=v.0.7.6
 HTTP_PORT=80

--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -22,7 +22,7 @@ DEFAULT_VOACAP_SERVICE_TAG=1.18
 DEFAULT_PSKR_MQTT_CACHE_TAG=1.14
 DEFAULT_WSPR_LIVE_CACHE_TAG=1.3
 
-GITHUB_LATEST_RELEASE_URL="https://api.github.com/repos/komacke/open-hamclock-backend/releases/latest"
+GITHUB_LATEST_RELEASE_URL="https://api.github.com/repos/openhamclock/open-hamclock-backend/releases/latest"
 OHB_HTDOCS_DVC=ohb-htdocs
 IMAGE_BASE=komacke/open-hamclock-backend
 

--- a/scripts/fetch_sat_freq.sh
+++ b/scripts/fetch_sat_freq.sh
@@ -58,7 +58,7 @@ FREQ_OUT="${ESATS_FREQ_OUT:-/opt/hamclock-backend/htdocs/ham/HamClock/esats/esat
 SATNOGS_API="${SATNOGS_API:-https://db.satnogs.org/api/transmitters/}"
 HTTP_TIMEOUT="${HTTP_TIMEOUT:-20}"     # seconds per request
 REQ_SLEEP="${REQ_SLEEP:-0.5}"          # polite delay between API calls, seconds
-USER_AGENT="${USER_AGENT:-OHB-fetch_sat_freq/1.0 (+https://github.com/komacke/open-hamclock-backend)}"
+USER_AGENT="${USER_AGENT:-OHB-fetch_sat_freq/1.0 (+https://github.com/openhamclock/open-hamclock-backend)}"
 
 ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 log() { echo "[$(ts)] $*" >&2; }

--- a/scripts/fetch_wwff_cache.pl
+++ b/scripts/fetch_wwff_cache.pl
@@ -28,7 +28,7 @@
 #  automatically if CQGMA_API_KEY is not set.
 #
 #  Part of the OHB project:
-#  https://github.com/komacke/open-hamclock-backend/tree/main
+#  https://github.com/openhamclock/open-hamclock-backend/tree/main
 #
 ##
 # Copyright (C) 2026 Open HamClock Backend (OHB) Contributors
@@ -93,7 +93,7 @@ for my $d (dirname($OUT), $TMP_DIR) {
 
 my $ua = LWP::UserAgent->new(
     timeout => 15,
-    agent   => 'OHB-WWFF-Cache/1.0 (+https://github.com/komacke/open-hamclock-backend; spot fetcher)',
+    agent   => 'OHB-WWFF-Cache/1.0 (+https://github.com/openhamclock/open-hamclock-backend; spot fetcher)',
 );
 
 my $resp = $ua->get($WWFF_URL);

--- a/scripts/gen_dxpeditions_spots.py
+++ b/scripts/gen_dxpeditions_spots.py
@@ -80,7 +80,7 @@ REQUEST_TIMEOUT = 20
 HEADERS = {
     'User-Agent': (
         'OHB-DXPeds/2.0 '
-        '(+https://github.com/komacke/open-hamclock-backend)'
+        '(+https://github.com/openhamclock/open-hamclock-backend)'
     )
 }
 

--- a/scripts/gen_onta.pl
+++ b/scripts/gen_onta.pl
@@ -13,7 +13,7 @@
 #  gen_onta.pl -- POTA / SOTA / WWFF on-the-air spot aggregator
 #
 #  Part of the OHB project:
-#  https://github.com/komacke/open-hamclock-backend/tree/main
+#  https://github.com/openhamclock/open-hamclock-backend/tree/main
 #
 #  Aggregates spots from POTA, SOTA, and WWFF. This script deduplicates
 #  activations, resolves location data from cached reference CSVs, and
@@ -220,7 +220,7 @@ my %park_lookup = (%sota_lookup, %wwff_lookup, %pota_lookup);
 
 my $ua = LWP::UserAgent->new(
     timeout => 10,
-    agent   => 'OHB/1.1 (+https://github.com/komacke/open-hamclock-backend)',
+    agent   => 'OHB/1.1 (+https://github.com/openhamclock/open-hamclock-backend)',
 );
 
 my $now = time();

--- a/scripts/poll_activenets.py
+++ b/scripts/poll_activenets.py
@@ -84,7 +84,7 @@ CLIENT_NAME   = "HamClock-OHB"
 SERVER_NAME   = ""              # "" = all servers, or e.g. "NETLOGGER"
 OUTPUT_PATH   = "/opt/hamclock-backend/htdocs/ham/HamClock/activenets/activenets.txt"
 HTTP_TIMEOUT  = 20              # seconds
-USER_AGENT    = "HamClock-OHB-ActiveNets/1.1 (+https://github.com/komacke/open-hamclock-backend)"
+USER_AGENT    = "HamClock-OHB-ActiveNets/1.1 (+https://github.com/openhamclock/open-hamclock-backend)"
 
 WRITE_TIMESTAMP_COMMENT = True  # first line: "# updated <UTC> ..."
 WRITE_COLUMN_HEADER     = True  # second line: the CSV column names

--- a/scripts/utility/verify_firmware_integrity.pl
+++ b/scripts/utility/verify_firmware_integrity.pl
@@ -85,8 +85,8 @@ $ua->agent("OHB-External-Verifier/1.0");
 
 # --- Self Upgrade ---
 if ($cmd_upgrade) {
-    logger("Checking for script updates from komacke/open-hamclock-backend...");
-    my $api_url = "https://api.github.com/repos/komacke/open-hamclock-backend/releases/latest";
+    logger("Checking for script updates from openhamclock/open-hamclock-backend...");
+    my $api_url = "https://api.github.com/repos/openhamclock/open-hamclock-backend/releases/latest";
     my $resp = $ua->get($api_url);
     if ($resp->is_success) {
         my $data = decode_json($resp->decoded_content);


### PR DESCRIPTION
We are finally moving the last repo into github.com/openhamclock. The move is done and github automatically generates redirects. However to be complete we should change all references to the new URL.

Note that the docker organization is still komacke so don't change those.