### PR TITLE
Fix log permissions and rotation

### DIFF
--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -857,13 +857,6 @@ determine_http_log() {
             if [ ! -e "$HERE/logs/lighttpd" ]; then
                 mkdir -p "$HERE/logs/lighttpd"
             fi
-            if [ "$(stat -c '%u' "$HERE/logs/lighttpd" 2>/dev/null)" != "33" ]; then
-                # perms need to be set for logrotate to work
-                echo
-                echo "WARNING: folder '$HERE/logs/lighttpd' needs the following permission:"
-                echo "   sudo chown 33 $HERE/logs/lighttpd"
-                echo
-            fi
         fi
     fi
 }
@@ -1125,6 +1118,7 @@ services:
       HOST_HOSTNAME: $HOST_HOSTNAME
       PSKR_UID: 1001
       WSPR_UID: 1002
+      HOST_USER_GID: $(id -g)
       VOACAP_SERVICE_HOST: $VOACAP_SERVICE_HOST
       PSKR_MQTT_CACHE_HOST: $PSKR_MQTT_CACHE_HOST
       $MAP_SIZES_MAPPING

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -72,6 +72,19 @@ echo "Starting lighttpd ..."
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
 
 echo "Starting nginx ..."
+# Enforce your exact required permissions and ownership
+if findmnt -M /var/log/nginx >/dev/null 2>&1; then
+    NGINX_GID=$HOST_USER_GID
+else
+    NGINX_GID=www-data
+fi
+# Pre-create the log files if they don't exist
+touch /var/log/nginx/access.log /var/log/nginx/error.log
+chown www-data:$NGINX_GID /var/log/nginx/*.log
+chmod 0640 /var/log/nginx/*.log
+# logrotate handles group correctly
+sed -i "s/__NGINX_GID__/$NGINX_GID/" /etc/logrotate.d/nginx
+# Hand over execution to Nginx
 /usr/sbin/nginx
 
 # only needs to be primed when docker volume container is instantiated

--- a/logrotate/nginx.logrotate
+++ b/logrotate/nginx.logrotate
@@ -3,10 +3,13 @@
     missingok
     rotate 15
     notifempty
-    copytruncate
     sharedscripts
+    create 0640 www-data www-data
 
     postrotate
+        chgrp __NGINX_GID__ /var/log/nginx/*.log
+        nginx -s reopen
+
         TODAY=$(date +%Y%m%d)
         TARGET="/var/log/nginx/access.log-$TODAY"
  


### PR DESCRIPTION
This happens to be an issue with fresh installs. When upgrading from the old lighttpd to ngnix, we get lucky.

If the logs are not mounted externally, just let things happen in an nginx sort of way. Updates to logrotate.

But if mounted externally we probably want the user to be able to read them so we set the group to the installing users's gid.