### PR TITLE
Rate limit wx.pl

### DIFF
--- a/ham/HamClock/wx.pl
+++ b/ham/HamClock/wx.pl
@@ -127,8 +127,21 @@ if (defined $lat && defined $lng && looks_like_coord($lat) && looks_like_coord($
     # approx_timezone_seconds() is intentionally last -- it has no DST awareness.
     $wx{timezone} = get_timezone_secs($lat, $lng);
 
-    # Weather: serve from cache if fresh; otherwise fetch and repopulate cache.
-    get_weather_cached($lat, $lng, \%wx);
+    if ($ENV{HTTP_X_RATE_LIMITED} || $ENV{RATE_LIMITED}) {
+        # Rate limited by Nginx: do not call upstream APIs.
+        # Use stale cache if available, otherwise serve default values.
+        my $file = cache_key('wx', $lat, $lng);
+        my $stale = cache_get($file, 2**31);
+        if ($stale) {
+            %wx = (%wx, %$stale);
+            $wx{_cache} = 'rate_limited_stale';
+        } else {
+            $wx{_cache} = 'rate_limited_default';
+        }
+    } else {
+        # Weather: serve from cache if fresh; otherwise fetch and repopulate cache.
+        get_weather_cached($lat, $lng, \%wx);
+    }
 
     # Barometer trend: like timezone, this is computed fresh every request
     # (not tied to $WX_TTL) since it's just a local file read/append, not an
@@ -216,6 +229,10 @@ sub get_timezone_secs {
     my $file = cache_key('tz', $lat, $lng);
     my $cached = cache_get($file, $TZ_TTL);
     return $cached->{offset} if $cached && defined $cached->{offset};
+
+    if ($ENV{HTTP_X_RATE_LIMITED} || $ENV{RATE_LIMITED}) {
+        return approx_timezone_seconds($lng);
+    }
 
     # 1. Open-Meteo timezone API -- free, no key, returns IANA name + utc_offset_seconds (DST-aware)
     my $tz = _tz_open_meteo($lat, $lng);

--- a/nginx-conf/default
+++ b/nginx-conf/default
@@ -54,7 +54,7 @@ server {
     # Fallback location when rate limited: proxies to wx.pl with X-Rate-Limited header
     # so wx.pl returns cached/default weather data with HTTP 200 OK, preventing client thundering herd
     location @wx_rate_limited {
-        proxy_pass http://127.0.0.1:8080/ham/HamClock/wx.pl;
+        proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.0;
 
         proxy_ignore_client_abort on;

--- a/nginx-conf/default
+++ b/nginx-conf/default
@@ -1,3 +1,6 @@
+# Rate limit zone for weather endpoint to respect OpenWeatherMap API limits
+limit_req_zone $binary_remote_addr zone=wx_limit:10m rate=50r/m;
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
@@ -21,6 +24,52 @@ server {
     # Buffer up to 2MB request bodies in RAM to prevent disk I/O latency and HTTP 499 client timeouts
     client_body_buffer_size 2m;
     client_body_timeout 60s;
+
+    # Rate limit /ham/HamClock/wx.pl to 50 requests per minute
+    location = /ham/HamClock/wx.pl {
+        limit_req zone=wx_limit burst=5 nodelay;
+        limit_req_status 429;
+        error_page 429 = @wx_rate_limited;
+
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.0;
+
+        # HamClock postDiags() closes TCP socket immediately after writing without reading response
+        proxy_ignore_client_abort on;
+
+        # Forward headers for proxy identification
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Disable buffering for CGI responsiveness
+        proxy_buffering off;
+
+        # Match VOACAP timeouts (up to 300s)
+        proxy_read_timeout 300s;
+        proxy_send_timeout 360s;
+    }
+
+    # Fallback location when rate limited: proxies to wx.pl with X-Rate-Limited header
+    # so wx.pl returns cached/default weather data with HTTP 200 OK, preventing client thundering herd
+    location @wx_rate_limited {
+        proxy_pass http://127.0.0.1:8080/ham/HamClock/wx.pl;
+        proxy_http_version 1.0;
+
+        proxy_ignore_client_abort on;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Rate-Limited "1";
+
+        proxy_buffering off;
+
+        proxy_read_timeout 300s;
+        proxy_send_timeout 360s;
+    }
 
     location / {
         proxy_pass http://127.0.0.1:8080;


### PR DESCRIPTION
Our service provider for weather information limits to 60 r/m at the free tier. Building maps takes 5 r/m. That leaves us up to 55. let's use 50.

We can't return 429's because HC does its aggressive retry thing and we'll get a stampede. So nginx detects the rate limit and passes into wx.pl. wx.pl uses a cached value if available or sends back the default garbage.