### PR TITLE
Send lightning strikes newest to oldest

### DIFF
--- a/scripts/ohb-proxy-daemon.pl
+++ b/scripts/ohb-proxy-daemon.pl
@@ -136,7 +136,7 @@ get '/ham/HamClock/lightning/strikes.pl' => sub {
     my $lat1   = $do_filter ? $lat * $DEG2RAD : 0;
 
     my $out = "";
-    for my $s (@{$data->{strikes}}) {
+    for my $s (reverse @{$data->{strikes}}) {
         my $age_s = int(($now_ms - $s->{strikeTime}) / 1000);
         next if $age_s < 0 || $age_s > $maxage;
 


### PR DESCRIPTION
The number of strikes plotted in HC is processed first to last and capped at 5000. Send the newest first so the newest strikes are plotted.