### PR TITLE
Address rare 502 errors

### DIFF
--- a/scripts/ohb-proxy-daemon.pl
+++ b/scripts/ohb-proxy-daemon.pl
@@ -34,8 +34,8 @@ my $voacap_host = $ENV{VOACAP_SERVICE_HOST}  || 'voacap-service:8080';
 # Connection Pools for each upstream target
 my $ua_pskr = Mojo::UserAgent->new
     ->connect_timeout(4)
-    ->inactivity_timeout(8)
-    ->request_timeout(12)
+    ->inactivity_timeout(12)
+    ->request_timeout(15)
     ->max_redirects(0);
 
 my $ua_band = Mojo::UserAgent->new


### PR DESCRIPTION
In conjunction with some changes to pskr-mqtt-cache, bump a couple of proxy timeouts to handle bursts better