### PR TITLE
Address possible keep-alive race condition

### DIFF
--- a/docker/manage-ohb-docker.sh
+++ b/docker/manage-ohb-docker.sh
@@ -19,7 +19,7 @@
 OHB_MANAGER_VERSION=latest
 # tags to use
 DEFAULT_VOACAP_SERVICE_TAG=1.19
-DEFAULT_PSKR_MQTT_CACHE_TAG=1.18
+DEFAULT_PSKR_MQTT_CACHE_TAG=1.19
 DEFAULT_WSPR_LIVE_CACHE_TAG=1.3
 
 GITHUB_LATEST_RELEASE_URL="https://api.github.com/repos/openhamclock/open-hamclock-backend/releases/latest"

--- a/scripts/ohb-proxy-daemon.pl
+++ b/scripts/ohb-proxy-daemon.pl
@@ -197,7 +197,10 @@ sub proxy_request {
            : ($endpoint =~ /fetchPSK/ ? $ua_pskr : $ua_voacap);
 
     my $original_ua = $c->req->headers->user_agent // 'OHB-Proxy/1.0';
-    my $tx = $ua->build_tx(GET => $url, {'User-Agent' => $original_ua});
+    my $tx = $ua->build_tx(GET => $url, {
+        'User-Agent' => $original_ua,
+        'Connection' => 'close',
+    });
 
     my $headers_sent = 0;
     my $aborted = 0;


### PR DESCRIPTION
We still get a very low rate of 502s from the server proxying to the pskr server. Since TCP sockets are managed on pskr there's as possible race condition. Tell the socket to close when complete.

Also bump to the new pskr tag.