### PR TITLE
Revert "Reduce or eliminate rare 408"

### DIFF
--- a/nginx-conf/default
+++ b/nginx-conf/default
@@ -24,9 +24,6 @@ server {
     # Buffer up to 2MB request bodies in RAM to prevent disk I/O latency and HTTP 499 client timeouts
     client_body_buffer_size 2m;
     client_body_timeout 60s;
-    client_header_timeout 60s;
-    send_timeout 60s;
-    reset_timedout_connection on;
 
     # Rate limit /ham/HamClock/wx.pl to 50 requests per minute
     location = /ham/HamClock/wx.pl {
@@ -46,8 +43,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # Buffer response to free backend Lighttpd connection immediately
-        proxy_buffering on;
+        # Disable buffering for CGI responsiveness
+        proxy_buffering off;
 
         # Match VOACAP timeouts (up to 300s)
         proxy_read_timeout 300s;
@@ -68,7 +65,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Rate-Limited "1";
 
-        proxy_buffering on;
+        proxy_buffering off;
 
         proxy_read_timeout 300s;
         proxy_send_timeout 360s;
@@ -87,8 +84,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # Buffer response to free backend Lighttpd connection immediately
-        proxy_buffering on;
+        # Disable buffering for CGI responsiveness
+        proxy_buffering off;
 
         # Match VOACAP timeouts (up to 300s)
         proxy_read_timeout 300s;


### PR DESCRIPTION
Reverts openhamclock/open-hamclock-backend#376

The 408s seem to have been cleaned up with the other fixes. Let's not do this and reassess after the next release.